### PR TITLE
MVAMet identification hash and changes to svfit hash

### DIFF
--- a/bin/ComputeSvfit.cc
+++ b/bin/ComputeSvfit.cc
@@ -54,30 +54,32 @@ int main(int argc, const char *argv[])
     {
         throw std::runtime_error("libKappa.so could not be found");
     }
-    ULong64_t run, lumi, event;
+    // Svfit Eventkey
+    ULong64_t runLumiEvent;
     svFitStandalone::kDecayType decayType1, decayType2;
-    int decayMode1, decayMode2;
     int systematicShift;
     float systematicShiftSigma;
     int integrationMethod;
+    uint64_t hash;
 
+    // Svfit Inputs
     RMFLV* leptonMomentum1 = new RMFLV();
     RMFLV* leptonMomentum2 = new RMFLV();
     RMDataV* metMomentum = new RMDataV();
     RMSM2x2* metCovariance = new RMSM2x2();
-    uint32_t hash;
+    int decayMode1, decayMode2;
 
-    uint64_t outrun, outlumi, outevent;
-    uint32_t outhash;
+    // keys for the output file
+    uint64_t outrunLumiEvent;
+    uint64_t outhash;
     int outdecayType1, outdecayType2;
-    int outdecayMode1, outdecayMode2;
     int outsystematicShift;
     float outsystematicShiftSigma;
     int outintegrationMethod;
-
+    
     RMFLV momentum;//, momentumUncertainty;
-    //RMDataV fittedMET;
     double transverseMass;//, transverseMassUncertainty;
+
     std::string inputfilename = vm["inputfile"].as<std::string>();
     char chars[] = "\"";
     removeCharsFromString(inputfilename, chars);
@@ -88,82 +90,72 @@ int main(int argc, const char *argv[])
     TFile *outfile = new TFile((vm["outputfile"].as<std::string>()).c_str(),"RECREATE");
     TTree *outputtree = new TTree("svfitCache","svfitCache");
 
-    inputtree->SetBranchAddress("run", &run);
-    inputtree->SetBranchAddress("lumi", &lumi);
-    inputtree->SetBranchAddress("event", &event);
+    // Svfit Eventkey
+    inputtree->SetBranchAddress("runLumiEvent", &runLumiEvent);
     inputtree->SetBranchAddress("systematicShift", &systematicShift);
     inputtree->SetBranchAddress("systematicShiftSigma", &systematicShiftSigma);
     inputtree->SetBranchAddress("integrationMethod", &integrationMethod);
     inputtree->SetBranchAddress("decayType1", &decayType1);
     inputtree->SetBranchAddress("decayType2", &decayType2);
-    inputtree->SetBranchAddress("decayMode1", &decayMode1);
-    inputtree->SetBranchAddress("decayMode2", &decayMode2);
+    inputtree->SetBranchAddress("hash", &hash);
 
+    // Svfit Inputs
     inputtree->SetBranchAddress("leptonMomentum1", &leptonMomentum1);
     inputtree->SetBranchAddress("leptonMomentum2", &leptonMomentum2);
     inputtree->SetBranchAddress("metMomentum", &metMomentum);
     inputtree->SetBranchAddress("metCovariance", &metCovariance);
-    inputtree->SetBranchAddress("hash", &hash);
+    inputtree->SetBranchAddress("decayMode1", &decayMode1);
+    inputtree->SetBranchAddress("decayMode2", &decayMode2);
 
-    inputtree->SetBranchStatus("run", true);
-    inputtree->SetBranchStatus("lumi", true);
-    inputtree->SetBranchStatus("event", true);
+    // Svfit Eventkey
+    inputtree->SetBranchStatus("runLumiEvent", true);
     inputtree->SetBranchStatus("systematicShift", true);
     inputtree->SetBranchStatus("systematicShiftSigma", true);
     inputtree->SetBranchStatus("integrationMethod", true);
     inputtree->SetBranchStatus("decayType1", true);
     inputtree->SetBranchStatus("decayType2", true);
+    inputtree->SetBranchStatus("hash", true);
 
+    // Svfit Inputs
     inputtree->SetBranchStatus("leptonMomentum1", true);
     inputtree->SetBranchStatus("leptonMomentum2", true);
     inputtree->SetBranchStatus("metMomentum", true);
     inputtree->SetBranchStatus("metCovariance", true);
-    inputtree->SetBranchStatus("hash", true);
+    inputtree->SetBranchStatus("decayMode1", true);
+    inputtree->SetBranchStatus("decayMode2", true);
 
-    outputtree->Branch("run", &outrun, "run/l");
-    outputtree->Branch("lumi", &outlumi, "lumi/l");
-    outputtree->Branch("event", &outevent, "event/l");
+    // Svfit Eventkey
+    outputtree->Branch("runLumiEvent", &outrunLumiEvent, "runLumiEvent/l");
     outputtree->Branch("systematicShift", &outsystematicShift);
     outputtree->Branch("systematicShiftSigma", &outsystematicShiftSigma);
     outputtree->Branch("integrationMethod", &outintegrationMethod);
     outputtree->Branch("decayType1", &outdecayType1);
     outputtree->Branch("decayType2", &outdecayType2);
-    outputtree->Branch("decayMode1", &outdecayMode1);
-    outputtree->Branch("decayMode2", &outdecayMode2);
-
-    //outputtree->Branch("leptonMomentum1", &leptonMomentum1);
-    //outputtree->Branch("leptonMomentum2", &leptonMomentum2);
-    //outputtree->Branch("metMomentum", &metMomentum);
-    //outputtree->Branch("metCovariance", &metCovariance);
     outputtree->Branch("hash", &outhash);
 
+
     outputtree->Branch("svfitMomentum", &momentum);
-    //outputtree->Branch("svfitMomentumUncertainty", &momentumUncertainty);
-    //outputtree->Branch("svfitMet", &fittedMET);
     outputtree->Branch("svfitTransverseMass", &transverseMass, "svfitTransverseMass/D");
-    //outputtree->Branch("svfitTransverseMassUnc", &transverseMassUncertainty, "svfitTransverseMassUnc/D");
+
     TDirectory *savedir(gDirectory);
     TFile *savefile(gFile);
     TString cmsswBase = TString( getenv ("CMSSW_BASE") );
     TFile* inputFile_visPtResolution = new TFile(cmsswBase+"/src/TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root");
     gDirectory = savedir;
     gFile = savefile;
+
     unsigned int nEntries = inputtree->GetEntries();
     for(unsigned int entry = 0; entry < nEntries; entry++)
     {
         std::cout << "Entry: " << entry << " / " << nEntries << std::endl;
         inputtree->GetEntry(entry);
 
-        outrun = run;
-        outlumi = lumi;
-        outevent = event;
+        outrunLumiEvent = runLumiEvent;
         outsystematicShift = systematicShift;
         outsystematicShiftSigma = systematicShiftSigma;
         outintegrationMethod = integrationMethod;
         outdecayType1 = decayType1;
         outdecayType2 = decayType2;
-        outdecayMode1 = decayMode1;
-        outdecayMode2 = decayMode2;
         outhash = hash;
         double leptonMass1 = 0;
         double leptonMass2 = 0;
@@ -222,19 +214,12 @@ int main(int argc, const char *argv[])
         }
 
         // retrieve results
-        //fittedMET = svfitStandaloneAlgorithm.fittedMET();
-        //momentumUncertainty.SetPt(svfitStandaloneAlgorithm.ptUncert());
-        //momentumUncertainty.SetEta(svfitStandaloneAlgorithm.etaUncert());
-        //momentumUncertainty.SetPhi(svfitStandaloneAlgorithm.phiUncert());
-        //momentumUncertainty.SetM(svfitStandaloneAlgorithm.massUncert());
-
         momentum.SetPt(svfitStandaloneAlgorithm.pt());
         momentum.SetEta(svfitStandaloneAlgorithm.eta());
         momentum.SetPhi(svfitStandaloneAlgorithm.phi());
         momentum.SetM(svfitStandaloneAlgorithm.mass());
 
         transverseMass = svfitStandaloneAlgorithm.transverseMass();
-        //transverseMassUncertainty = svfitStandaloneAlgorithm.transverseMassUncert();
 
         outputtree->Fill();
     }

--- a/data/ArtusConfigs/Run2MSSM/JECunc.json
+++ b/data/ArtusConfigs/Run2MSSM/JECunc.json
@@ -5,6 +5,7 @@
 				"Run2015" : 0.0,
 				"default" : 0.0
 			}
-		}
+		},
+		"SvfitCacheFileFolder" : "jecUncNom"
 	}
 }

--- a/data/ArtusConfigs/Run2MSSM/JECunc_tauES_shifts.json
+++ b/data/ArtusConfigs/Run2MSSM/JECunc_tauES_shifts.json
@@ -6,7 +6,8 @@
 				"default" : 0.0
 			}
 		},
-		"TauEnergyCorrectionShift" : 1.0
+		"TauEnergyCorrectionShift" : 1.0,
+		"SvfitCacheFileFolder" : "jecUncNom_tauEsNom"
 	},
 	"jecUncNom_tauEsUp" : {
 		"JetEnergyCorrectionUncertaintyShift" : {
@@ -20,7 +21,8 @@
 				"default" : 1.0,
 				"HToTauTau|DY.?JetsToLL" : 1.03
 			}
-		}
+		},
+		"SvfitCacheFileFolder" : "jecUncNom_tauEsUp"
 	},
 	"jecUncNom_tauEsDown" : {
 		"JetEnergyCorrectionUncertaintyShift" : {
@@ -34,7 +36,8 @@
 				"default" : 1.0,
 				"HToTauTau|DY.?JetsToLL" : 0.97
 			}
-		}
+		},
+		"SvfitCacheFileFolder" : "jecUncNom_tauEsDowm"
 	},
 	"jecUncUp_tauEsNom" : {
 		"JetEnergyCorrectionUncertaintyShift" : {
@@ -43,7 +46,8 @@
 				"default" : 1.0
 			}
 		},
-		"TauEnergyCorrectionShift" : 1.0
+		"TauEnergyCorrectionShift" : 1.0,
+		"SvfitCacheFileFolder" : "jecUncUp_tauEsNom"
 	},
 	"jecUncDown_tauEsNom" : {
 		"JetEnergyCorrectionUncertaintyShift" : {
@@ -52,6 +56,7 @@
 				"default" : -1.0
 			}
 		},
-		"TauEnergyCorrectionShift" : 1.0
+		"TauEnergyCorrectionShift" : 1.0,
+		"SvfitCacheFileFolder" : "jecUncDown_tauENom"
 	}
 }

--- a/interface/HttSettings.h
+++ b/interface/HttSettings.h
@@ -212,6 +212,7 @@ public:
 	IMPL_SETTING(std::string, SvfitIntegrationMethod);
 	IMPL_SETTING_DEFAULT(std::string, SvfitCacheFile, "");
 	IMPL_SETTING_DEFAULT(std::string, SvfitCacheTree, "svfitCache");
+	IMPL_SETTING_DEFAULT(std::string, SvfitCacheFileFolder, "");
 	IMPL_SETTING_DEFAULT(std::string, SvfitCacheFilePrefix, "");
 	IMPL_SETTING_DEFAULT(bool, UseFirstInputFileNameForSvfit, false);
 	IMPL_SETTING_DEFAULT(std::string, SvfitCacheMissBehaviour, "assert");

--- a/interface/Utility/SvfitTools.h
+++ b/interface/Utility/SvfitTools.h
@@ -39,28 +39,24 @@ public:
 		else return IntegrationMethod::NONE;
 	}
 	
-	uint64_t run;
-	uint64_t lumi;
-	uint64_t event;
+	uint64_t runLumiEvent;
 	int decayType1;
 	int decayType2;
-	int decayMode1;
-	int decayMode2;
 	int systematicShift;
 	float systematicShiftSigma;
 	int integrationMethod;
-	uint32_t hash;
+	uint64_t hash;
 	
 	SvfitEventKey() {};
-	SvfitEventKey(uint64_t const& run, uint64_t const& lumi, uint64_t const& event,
+	SvfitEventKey(uint64_t const& runLumiEvent,
 	              svFitStandalone::kDecayType const& decayType1, svFitStandalone::kDecayType const& decayType2,
-	              int const& decayMode1, int const& decayMode2, HttEnumTypes::SystematicShift const& systematicShift,
-	              float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint32_t const &hash);
+	              HttEnumTypes::SystematicShift const& systematicShift,
+	              float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint64_t const &hash);
 	
-	void Set(uint64_t const& run, uint64_t const& lumi, uint64_t const& event,
+	void Set(uint64_t const& runLumiEvent,
 	         svFitStandalone::kDecayType const& decayType1, svFitStandalone::kDecayType const& decayType2,
-	         int const& decayMode1, int const& decayMode2, HttEnumTypes::SystematicShift const& systematicShift,
-	         float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint32_t const &hash);
+	         HttEnumTypes::SystematicShift const& systematicShift,
+	         float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint64_t const &hash);
 	
 	HttEnumTypes::SystematicShift GetSystematicShift() const;
 	IntegrationMethod GetIntegrationMethod() const;
@@ -91,14 +87,19 @@ public:
 	
 	RMDataV* metMomentum = 0;
 	RMSM2x2* metCovariance = 0;
+
+	int* decayMode1 = 0;
+	int* decayMode2 = 0;
 	
 	SvfitInputs() {};
 	SvfitInputs(RMFLV const& leptonMomentum1, RMFLV const& leptonMomentum2,
-	            RMDataV const& metMomentum, RMSM2x2 const& metCovariance);
+	            RMDataV const& metMomentum, RMSM2x2 const& metCovariance,
+	            int const& decayMode1, int const& decayMode2);
 	~SvfitInputs();
 	
 	void Set(RMFLV const& leptonMomentum1, RMFLV const& leptonMomentum2,
-	         RMDataV const& metMomentum, RMSM2x2 const& metCovariance);
+	         RMDataV const& metMomentum, RMSM2x2 const& metCovariance,
+	         int const& decayMode1, int const& decayMode2);
 	
 	void CreateBranches(TTree* tree);
 	void SetBranchAddresses(TTree* tree);
@@ -108,8 +109,6 @@ public:
 	bool operator!=(SvfitInputs const& rhs) const;
 	
 	SVfitStandaloneAlgorithm GetSvfitStandaloneAlgorithm(SvfitEventKey const& svfitEventKey, int verbosity=0, bool addLogM=false) const;
-
-	uint32_t GetHash();
 
 private:
 	std::vector<svFitStandalone::MeasuredTauLepton> GetMeasuredTauLeptons(SvfitEventKey const& svfitEventKey) const;

--- a/scripts/submitCrabSvfitJobs.py
+++ b/scripts/submitCrabSvfitJobs.py
@@ -88,57 +88,57 @@ def submission(base_path):
 	from CRABClient.UserUtilities import config
 	config = config()
 	today=datetime.date.today().strftime("%Y-%m-%d")
-	allowed_paths = [f for f in glob(base_path+"/*") if not ("tar.gz" in f)]
-	for path in allowed_paths:
-		dataset_nick = path.split('/')[-1]
-		print "nick: " + dataset_nick
-		print "path: " +path
-		files =0
-		cache_files = [f for f in glob(path+"/*.root") if("SvfitCache" in f)]
-		if len(cache_files) == 0:
-			continue
-		jobfile_name = get_filename(today,dataset_nick)
-		jobfile = open(jobfile_name,"w+") 
-		jobfile.write("#!/bin/bash\n")
-		jobfile.write("declare -A arr\n")
-		jobfile.write(CRAB_PREFIX)
-		for index,file in enumerate(cache_files):
-			jobfile.write("arr[%s,0]=dcap://dcache-cms-dcap.desy.de/%s\n"%(index+1,file))
-		jobfile.write("if [ \"x$2\" != \"x\" ]; then\npushd %s\nSCRAM_ARCH=slc6_amd64_gcc493\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\neval `scramv1 runtime -sh`\n"%(os.getcwd()))
-		jobfile.write("ComputeSvfit -i ${arr[$1,0]} -o SvfitCache.root\n")
-		jobfile.write("else\n./ComputeSvfit -i ${arr[$1,0]} -o SvfitCache.root\nfi\n")
-		jobfile.close()
-		
-		config.General.workArea = '/nfs/dust/cms/user/%s/%s/'%(getUsernameFromSiteDB(),today)
-		config.General.transferOutputs = True
-		config.General.transferLogs = True
-		jobname = "SvFit_"+today+"_"+dataset_nick.split("_MINIAOD")[0]
-		config.General.requestName = jobname
-		print jobname
-		config.Data.outputPrimaryDataset = 'Svfit'
-		config.Data.splitting = 'EventBased'
-		config.Data.unitsPerJob = 1
-		config.Data.totalUnits = len(cache_files)
-		config.Data.publication = False
-		config.Data.outputDatasetTag = config.General.requestName
-		config.Data.outLFNDirBase = '/store/user/%s/higgs-kit/Svfit/%s/%s/'%(getUsernameFromSiteDB(),today,dataset_nick)
-		print "outdir: " + config.Data.outLFNDirBase
-		config.Data.publication = False
-		
-		config.User.voGroup = 'dcms'
-		
-		config.JobType.pluginName = 'PrivateMC'
-		config.JobType.psetName = os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/do_nothing_cfg.py'
-		config.JobType.inputFiles = ['Kappa/lib/libKappa.so', os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/ComputeSvfit', jobfile_name]
-		config.JobType.allowUndistributedCMSSW = True
-		config.JobType.scriptExe = jobfile_name
-		config.JobType.outputFiles = ['SvfitCache.root']
+	files =0
+	cache_files = [f for f in glob(base_path+"/*/*.root") if("SvfitCache" in f)]
+	if len(cache_files) == 0:
+		continue
+	if len(cache_files > 8000):
+            cache_files = [cache_files[i:i+8000] for i in xrange(0,len(cache_files),8000)]
+        else:
+            cache_files = [cache_files]
+        for index,cache_file enumerate(cache_files):
+            jobfile_name = get_filename(today,index)
+            jobfile = open(jobfile_name,"w+")
+            jobfile.write("#!/bin/bash\n")
+            jobfile.write("declare -A arr\n")
+            jobfile.write(CRAB_PREFIX)
+            for index,file in enumerate(cache_file):
+                    jobfile.write("arr[%s,0]=dcap://dcache-cms-dcap.desy.de/%s\n"%(index+1,file))
+            jobfile.write("if [ \"x$2\" != \"x\" ]; then\npushd %s\nSCRAM_ARCH=slc6_amd64_gcc493\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\neval `scramv1 runtime -sh`\n"%(os.getcwd()))
+            jobfile.write("ComputeSvfit -i ${arr[$1,0]} -o SvfitCache.root\n")
+            jobfile.write("else\n./ComputeSvfit -i ${arr[$1,0]} -o $(basename ${arr[$1,0]})\ntar -cf $(basename ${arr[$1,0]})\nfi\n")
+            jobfile.close()
 			
-		config.Site.storageSite = "T2_DE_DESY"
-			# config.Site.blacklist = ["T3_US_PuertoRico","T2_ES_CIEMAT","T2_DE_RWTH","T3_US_Colorado","T2_BR_UERJ","T2_ES_IFCA","T2_RU_JINR","T2_UA_KIPT","T2_EE_Estonia","T2_FR_GRIF_LLR","T2_CH_CERN","T2_FR_GRIF_LLR","T3_IT_Bologna","T2_US_Nebraska","T2_US_Nebraska","T3_TW_NTU_HEP","T2_US_Caltech","T3_US_Cornell","T2_IT_Legnaro","T2_HU_Budapest","T2_IT_Pisa","T2_US_Florida",'T2_IT_Bari',"T2_FR_GRIF_IRFU","T2_IT_Rome","T2_FR_GRIF_IRFU","T2_CH_CSCS","T3_TW_NCU"]
-		p = Process(target=submit, args=(config,))
-		p.start()
-		p.join()
+            config.General.workArea = '/nfs/dust/cms/user/%s/%s/'%(getUsernameFromSiteDB(),today)
+            config.General.transferOutputs = True
+            config.General.transferLogs = True
+            jobname = "SvFit_"+today
+            config.General.requestName = jobname
+            print jobname
+            config.Data.outputPrimaryDataset = 'Svfit'
+            config.Data.splitting = 'EventBased'
+            config.Data.unitsPerJob = 1
+            config.Data.totalUnits = len(cache_files)
+            config.Data.publication = False
+            config.Data.outputDatasetTag = config.General.requestName
+            config.Data.outLFNDirBase = '/store/user/%s/higgs-kit/Svfit/%s/'%(getUsernameFromSiteDB(),today)
+            print "outdir: " + config.Data.outLFNDirBase
+            config.Data.publication = False
+			
+            config.User.voGroup = 'dcms'
+			
+            config.JobType.pluginName = 'PrivateMC'
+            config.JobType.psetName = os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/do_nothing_cfg.py'
+            config.JobType.inputFiles = ['Kappa/lib/libKappa.so', os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/ComputeSvfit', jobfile_name]
+            config.JobType.allowUndistributedCMSSW = True
+            config.JobType.scriptExe = jobfile_name
+            config.JobType.outputFiles = ['SvfitCache.tar.gz']
+			
+            config.Site.storageSite = "T2_DE_DESY"
+                    # config.Site.blacklist = ["T3_US_PuertoRico","T2_ES_CIEMAT","T2_DE_RWTH","T3_US_Colorado","T2_BR_UERJ","T2_ES_IFCA","T2_RU_JINR","T2_UA_KIPT","T2_EE_Estonia","T2_FR_GRIF_LLR","T2_CH_CERN","T2_FR_GRIF_LLR","T3_IT_Bologna","T2_US_Nebraska","T2_US_Nebraska","T3_TW_NTU_HEP","T2_US_Caltech","T3_US_Cornell","T2_IT_Legnaro","T2_HU_Budapest","T2_IT_Pisa","T2_US_Florida",'T2_IT_Bari',"T2_FR_GRIF_IRFU","T2_IT_Rome","T2_FR_GRIF_IRFU","T2_CH_CSCS","T3_TW_NCU"]
+            p = Process(target=submit, args=(config,))
+            p.start()
+            p.join()
 
 if __name__ == "__main__":
 	if len(sys.argv) == 1: 

--- a/src/Utility/SvfitTools.cc
+++ b/src/Utility/SvfitTools.cc
@@ -8,26 +8,22 @@
 
 TChain* SvfitTools::svfitCacheInputTree = 0;
 
-SvfitEventKey::SvfitEventKey(uint64_t const& run, uint64_t const& lumi, uint64_t const& event,
+SvfitEventKey::SvfitEventKey(uint64_t const& runLumiEvent,
                              svFitStandalone::kDecayType const& decayType1, svFitStandalone::kDecayType const& decayType2,
-                             int const& decayMode1, int const& decayMode2, HttEnumTypes::SystematicShift const& systematicShift,
-                             float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint32_t const& hash)
+                             HttEnumTypes::SystematicShift const& systematicShift,
+                             float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint64_t const& hash)
 {
-	Set(run, lumi, event, decayType1, decayType2, decayMode1, decayMode2, systematicShift, systematicShiftSigma, integrationMethod, hash);
+	Set(runLumiEvent, decayType1, decayType2, systematicShift, systematicShiftSigma, integrationMethod, hash);
 }
 
-void SvfitEventKey::Set(uint64_t const& run, uint64_t const& lumi, uint64_t const& event,
+void SvfitEventKey::Set(uint64_t const& runLumiEvent,
                         svFitStandalone::kDecayType const& decayType1, svFitStandalone::kDecayType const& decayType2,
-                        int const& decayMode1, int const& decayMode2, HttEnumTypes::SystematicShift const& systematicShift,
-                        float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint32_t const& hash)
+                        HttEnumTypes::SystematicShift const& systematicShift,
+                        float const& systematicShiftSigma, IntegrationMethod const& integrationMethod, uint64_t const& hash)
 {
-	this->run = run;
-	this->lumi = lumi;
-	this->event = event;
+	this->runLumiEvent = runLumiEvent;
 	this->decayType1 = Utility::ToUnderlyingValue(decayType1);
 	this->decayType2 = Utility::ToUnderlyingValue(decayType2);
-	this->decayMode1 = decayMode1;
-	this->decayMode2 = decayMode2;
 	this->systematicShift = Utility::ToUnderlyingValue<HttEnumTypes::SystematicShift>(systematicShift);
 	this->systematicShiftSigma = systematicShiftSigma;
 	this->integrationMethod = Utility::ToUnderlyingValue<IntegrationMethod>(integrationMethod);
@@ -46,13 +42,9 @@ SvfitEventKey::IntegrationMethod SvfitEventKey::GetIntegrationMethod() const
 
 void SvfitEventKey::CreateBranches(TTree* tree)
 {
-	tree->Branch("run", &run, "run/l");
-	tree->Branch("lumi", &lumi, "lumi/l");
-	tree->Branch("event", &event, "event/l");
+	tree->Branch("runLumiEvent", &runLumiEvent, "runLumiEvent/l");
 	tree->Branch("decayType1", &decayType1);
 	tree->Branch("decayType2", &decayType2);
-	tree->Branch("decayMode1", &decayMode1);
-	tree->Branch("decayMode2", &decayMode2);
 	tree->Branch("systematicShift", &systematicShift);
 	tree->Branch("systematicShiftSigma", &systematicShiftSigma);
 	tree->Branch("integrationMethod", &integrationMethod);
@@ -61,13 +53,9 @@ void SvfitEventKey::CreateBranches(TTree* tree)
 
 void SvfitEventKey::SetBranchAddresses(TTree* tree)
 {
-	tree->SetBranchAddress("run", &run);
-	tree->SetBranchAddress("lumi", &lumi);
-	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("runLumiEvent", &runLumiEvent);
 	tree->SetBranchAddress("decayType1", &decayType1);
 	tree->SetBranchAddress("decayType2", &decayType2);
-	tree->SetBranchAddress("decayMode1", &decayMode1);
-	tree->SetBranchAddress("decayMode2", &decayMode2);
 	tree->SetBranchAddress("systematicShift", &systematicShift);
 	tree->SetBranchAddress("systematicShiftSigma", &systematicShiftSigma);
 	tree->SetBranchAddress("integrationMethod", &integrationMethod);
@@ -77,13 +65,9 @@ void SvfitEventKey::SetBranchAddresses(TTree* tree)
 
 void SvfitEventKey::ActivateBranches(TTree* tree, bool activate)
 {
-	tree->SetBranchStatus("run", activate);
-	tree->SetBranchStatus("lumi", activate);
-	tree->SetBranchStatus("event", activate);
+	tree->SetBranchStatus("runLumiEvent", activate);
 	tree->SetBranchStatus("decayType1", activate);
 	tree->SetBranchStatus("decayType2", activate);
-	tree->SetBranchStatus("decayMode1", activate);
-	tree->SetBranchStatus("decayMode2", activate);
 	tree->SetBranchStatus("systematicShift", activate);
 	tree->SetBranchStatus("systematicShiftSigma", activate);
 	tree->SetBranchStatus("integrationMethod", activate);
@@ -92,85 +76,55 @@ void SvfitEventKey::ActivateBranches(TTree* tree, bool activate)
 
 bool SvfitEventKey::operator<(SvfitEventKey const& rhs) const
 {
-	if (run == rhs.run)
+	if (runLumiEvent == rhs.runLumiEvent)
 	{
-		if (lumi == rhs.lumi)
-		{
-			if (event == rhs.event)
-			{
-				if (decayType1 == rhs.decayType1)
-				{
-					if (decayType2 == rhs.decayType2)
-					{
-						if (decayMode1 == rhs.decayMode1)
-						{
-							if (decayMode2 == rhs.decayMode2)
-							{
-								if (integrationMethod == rhs.integrationMethod)
-								{
-									if (systematicShift == rhs.systematicShift)
-									{
-										if (hash == rhs.hash)
-										{
-											return (systematicShiftSigma < rhs.systematicShiftSigma);
-										}
-										else
-										{
-											return (hash < rhs.hash);
-										}
-									}
-									else
-									{
-										return (systematicShift < rhs.systematicShift);
-									}
-								}
-								else
-								{
-									return (integrationMethod < rhs.integrationMethod);
-								}
-							}
-							else
-							{
-								return (decayMode2 < rhs.decayMode2);
-							}
-						}
-						else
-						{
-							return (decayMode1 < rhs.decayMode1);
-						}
-					}
-					else
-					{
-						return (decayType2 < rhs.decayType2);
-					}
-				}
-				else
-				{
-					return (decayType1 < rhs.decayType1);
-				}
-			}
-			else
-			{
-				return (event < rhs.event);
-			}
-		}
-		else
-		{
-			return (lumi < rhs.lumi);
-		}
+        if (decayType1 == rhs.decayType1)
+        {
+            if (decayType2 == rhs.decayType2)
+            {
+                if (integrationMethod == rhs.integrationMethod)
+                {
+                    if (systematicShift == rhs.systematicShift)
+                    {
+                        if (hash == rhs.hash)
+                        {
+                            return (systematicShiftSigma < rhs.systematicShiftSigma);
+                        }
+                        else
+                        {
+                            return (hash < rhs.hash);
+                        }
+                    }
+                    else
+                    {
+                        return (systematicShift < rhs.systematicShift);
+                    }
+                }
+                else
+                {
+                    return (integrationMethod < rhs.integrationMethod);
+                }
+            }
+            else
+            {
+                return (decayType2 < rhs.decayType2);
+            }
+        }
+        else
+        {
+            return (decayType1 < rhs.decayType1);
+        }
 	}
 	else {
-		return (run < rhs.run);
+		return (runLumiEvent < rhs.runLumiEvent);
 	}
 }
 
 bool SvfitEventKey::operator==(SvfitEventKey const& rhs) const
 {
-	return ((run == rhs.run) && (lumi == rhs.lumi) && (event == rhs.event) &&
+	return ((runLumiEvent == rhs.runLumiEvent) &&
 	        (decayType1 == rhs.decayType1) &&
 	        (decayType2 == rhs.decayType2) &&
-	        (decayMode1 == rhs.decayMode1) &&
-	        (decayMode2 == rhs.decayMode2) &&
 	        (integrationMethod == rhs.integrationMethod) &&
 	        (systematicShift == rhs.systematicShift) &&
 	        CutRange::EqualsCut(systematicShiftSigma).IsInRange(rhs.systematicShiftSigma) &&
@@ -185,13 +139,9 @@ bool SvfitEventKey::operator!=(SvfitEventKey const& rhs) const
 std::string std::to_string(SvfitEventKey const& svfitEventKey)
 {
 	return std::string("SvfitEventKey(") +
-			"run=" + std::to_string(svfitEventKey.run) + ", " +
-			"lumi=" + std::to_string(svfitEventKey.lumi) + ", " +
-			"event=" + std::to_string(svfitEventKey.event) + ", " +
+			"runLumiEvent=" + std::to_string(svfitEventKey.runLumiEvent) + ", " +
 			"decayType1=" + std::to_string(svfitEventKey.decayType1) + ", " +
 			"decayType2=" + std::to_string(svfitEventKey.decayType2) + ", " +
-			"decayMode1=" + std::to_string(svfitEventKey.decayMode1) + ", " +
-			"decayMode2=" + std::to_string(svfitEventKey.decayMode2) + ", " +
 			"systematicShift=" + std::to_string(svfitEventKey.systematicShift) + ", " +
 			"systematicShiftSigma=" + std::to_string(svfitEventKey.systematicShiftSigma) + ", " +
 			"integrationMethod=" + std::to_string(svfitEventKey.integrationMethod) + "," +
@@ -204,10 +154,11 @@ std::ostream& operator<<(std::ostream& os, SvfitEventKey const& svfitEventKey)
 }
 
 SvfitInputs::SvfitInputs(RMFLV const& leptonMomentum1, RMFLV const& leptonMomentum2,
-                         RMDataV const& metMomentum, RMSM2x2 const& metCovariance)
+                         RMDataV const& metMomentum, RMSM2x2 const& metCovariance,
+                         int const& decayMode1, int const& decayMode2)
 	: SvfitInputs()
 {
-	Set(leptonMomentum1, leptonMomentum2, metMomentum, metCovariance);
+	Set(leptonMomentum1, leptonMomentum2, metMomentum, metCovariance, decayMode1, decayMode2);
 }
 
 SvfitInputs::~SvfitInputs()
@@ -233,7 +184,8 @@ SvfitInputs::~SvfitInputs()
 }
 
 void SvfitInputs::Set(RMFLV const& leptonMomentum1, RMFLV const& leptonMomentum2,
-                      RMDataV const& metMomentum, RMSM2x2 const& metCovariance)
+                      RMDataV const& metMomentum, RMSM2x2 const& metCovariance,
+                      int const& decayMode1, int const& decayMode2)
 {
 	if (! this->leptonMomentum1)
 	{
@@ -251,11 +203,21 @@ void SvfitInputs::Set(RMFLV const& leptonMomentum1, RMFLV const& leptonMomentum2
 	{
 		this->metCovariance = new RMSM2x2();
 	}
+	if (! this->decayMode1)
+	{
+		this->decayMode1 = new int;
+	}
+	if (! this->decayMode2)
+	{
+		this->decayMode2 = new int;
+	}
 	
 	*(this->leptonMomentum1) = leptonMomentum1;
 	*(this->leptonMomentum2) = leptonMomentum2;
 	*(this->metMomentum) = metMomentum;
 	*(this->metCovariance) = metCovariance;
+	*(this->decayMode1) = decayMode1;
+	*(this->decayMode2) = decayMode2;
 }
 
 void SvfitInputs::CreateBranches(TTree* tree)
@@ -264,6 +226,8 @@ void SvfitInputs::CreateBranches(TTree* tree)
 	tree->Branch("leptonMomentum2", "RMFLV", &leptonMomentum2);
 	tree->Branch("metMomentum", "ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>", &metMomentum);
 	tree->Branch("metCovariance", "ROOT::Math::SMatrix<double, 2, 2, ROOT::Math::MatRepSym<double, 2> >", &metCovariance);
+	tree->Branch("decayMode1", &decayMode1);
+	tree->Branch("decayMode2", &decayMode2);
 }
 
 void SvfitInputs::SetBranchAddresses(TTree* tree)
@@ -272,6 +236,8 @@ void SvfitInputs::SetBranchAddresses(TTree* tree)
 	tree->SetBranchAddress("leptonMomentum2", &leptonMomentum2);
 	tree->SetBranchAddress("metMomentum", &metMomentum);
 	tree->SetBranchAddress("metCovariance", &metCovariance);
+	tree->SetBranchAddress("decayMode1", &decayMode1);
+	tree->SetBranchAddress("decayMode2", &decayMode2);
 	ActivateBranches(tree, true);
 }
 
@@ -281,6 +247,8 @@ void SvfitInputs::ActivateBranches(TTree* tree, bool activate)
 	tree->SetBranchStatus("leptonMomentum2", activate);
 	tree->SetBranchStatus("metMomentum", activate);
 	tree->SetBranchStatus("metCovariance", activate);
+	tree->SetBranchStatus("decayMode1", activate);
+	tree->SetBranchStatus("decayMode2", activate);
 }
 
 bool SvfitInputs::operator==(SvfitInputs const& rhs) const
@@ -288,19 +256,14 @@ bool SvfitInputs::operator==(SvfitInputs const& rhs) const
 	return (Utility::ApproxEqual(*leptonMomentum1, *(rhs.leptonMomentum1)) &&
 	        Utility::ApproxEqual(*leptonMomentum2, *(rhs.leptonMomentum2)) &&
 	        Utility::ApproxEqual(*metMomentum, *(rhs.metMomentum)) &&
-	        Utility::ApproxEqual(*metCovariance, *(rhs.metCovariance)));
+	        Utility::ApproxEqual(*metCovariance, *(rhs.metCovariance)) &&
+	        (*decayMode1 == *(rhs.decayMode1)) &&
+	        (*decayMode2 == *(rhs.decayMode2)));
 }
 
 bool SvfitInputs::operator!=(SvfitInputs const& rhs) const
 {
 	return (! (*this == rhs));
-}
-
-uint32_t SvfitInputs::GetHash()
-{
-	return ( getLVChargeHash(leptonMomentum1->pt(), leptonMomentum1->eta(), leptonMomentum1->phi(), leptonMomentum1->M(), 1) ^
-	         getLVChargeHash(leptonMomentum2->pt(), leptonMomentum2->eta(), leptonMomentum2->phi(), leptonMomentum2->M(), -1) ^
-	         getLVChargeHash(metMomentum->x(), metCovariance->At(0, 0), metMomentum->y(), metCovariance->At(1, 1), 0) );
 }
 
 SVfitStandaloneAlgorithm SvfitInputs::GetSvfitStandaloneAlgorithm(SvfitEventKey const& svfitEventKey, int verbosity, bool addLogM) const
@@ -342,8 +305,8 @@ std::vector<svFitStandalone::MeasuredTauLepton> SvfitInputs::GetMeasuredTauLepto
         leptonMass2 = leptonMomentum2->M();
     }
 	std::vector<svFitStandalone::MeasuredTauLepton> measuredTauLeptons {
-		svFitStandalone::MeasuredTauLepton(Utility::ToEnum<svFitStandalone::kDecayType>(svfitEventKey.decayType1), leptonMomentum1->pt(), leptonMomentum1->eta(), leptonMomentum1->phi(), leptonMass1,svfitEventKey.decayMode1),
-		svFitStandalone::MeasuredTauLepton(Utility::ToEnum<svFitStandalone::kDecayType>(svfitEventKey.decayType2), leptonMomentum2->pt(), leptonMomentum2->eta(), leptonMomentum2->phi(), leptonMass2,svfitEventKey.decayMode2)
+		svFitStandalone::MeasuredTauLepton(Utility::ToEnum<svFitStandalone::kDecayType>(svfitEventKey.decayType1), leptonMomentum1->pt(), leptonMomentum1->eta(), leptonMomentum1->phi(), leptonMass1, *decayMode1),
+		svFitStandalone::MeasuredTauLepton(Utility::ToEnum<svFitStandalone::kDecayType>(svfitEventKey.decayType2), leptonMomentum2->pt(), leptonMomentum2->eta(), leptonMomentum2->phi(), leptonMass2, *decayMode2)
 	};
 	return measuredTauLeptons;
 }


### PR DESCRIPTION
Dear all,

this pull request includes the changes needed to adapt the MetSelector to the changes for the MET-lepton identification method in Kappa (currently on the CMSSW_8_0_X branch).
In addition as mentioned in a previous mail I changes the Svfit-identification hash to be the same as the MET-hash and enhanced the code to facilitate storing the svfit caches in different directories for each pipeline. This also required adapting the svfit-calculation, job-submission and cache-merging scripts.

The changes are intended to be merged together with other potentially needed changes once we switch over to the new skims.
Please let me know if you have any input on these changes.

Cheers,
Rene