### PR TITLE
New em

### DIFF
--- a/python/plotting/configs/cutstrings.py
+++ b/python/plotting/configs/cutstrings.py
@@ -339,6 +339,10 @@ class CutStringsDict:
 			cuts = CutStringsDict.baseline(channel, cut_type)
 			cuts["iso_1"] = "(iso_1 < 0.3)"
 			cuts["iso_2"] = "(byMediumIsolationMVArun2v1DBoldDMwLT_2 > 0.5)"
+		elif channel in ["em"]:
+			cuts = CutStringsDict.baseline(channel, cut_type)
+			cuts["iso_1"] = "(iso_1 < 0.3)"
+			cuts["iso_2"] = "(iso_1 < 0.3)"
 		else:
 			log.fatal("No cut values implemented for channel \"%s\" in \"%s\"" % (channel, cut_type))
 			sys.exit(1)

--- a/python/plotting/configs/samples_run2_2016.py
+++ b/python/plotting/configs/samples_run2_2016.py
@@ -1365,10 +1365,10 @@ class Samples(samples.SamplesBase):
 
 				if not "EstimateQcd" in config.get("analysis_modules", []):
 					config.setdefault("analysis_modules", []).append("EstimateQcd")
-				config.setdefault("qcd_data_shape_nicks", []).append("qcd"+nick_suffix)
-				config.setdefault("qcd_data_yield_nicks", []).append("noplot_data_qcd_yield"+nick_suffix)
-				config.setdefault("qcd_data_control_nicks", []).append("noplot_data_qcd_control"+nick_suffix)
-				config.setdefault("qcd_data_substract_nicks", []).append(" ".join([nick+nick_suffix for nick in "noplot_ztt_mc_qcd_control noplot_zll_qcd_control noplot_ttj_qcd_control noplot_vv_qcd_control noplot_wj_ss".split()]))
+				config.setdefault("qcd_shape_nicks", []).append("qcd"+nick_suffix)
+				config.setdefault("qcd_yield_nicks", []).append("noplot_data_qcd_yield"+nick_suffix)
+				config.setdefault("qcd_yield_subtract_nicks", []).append(" ".join([nick+nick_suffix for nick in "noplot_ztt_mc_qcd_control noplot_zll_qcd_control noplot_ttj_qcd_control noplot_vv_qcd_control noplot_wj_ss".split()]))
+				config.setdefault("qcd_shape_subtract_nicks", []).append(" ".join([nick+nick_suffix for nick in "noplot_ztt_mc_qcd_control noplot_zll_qcd_control noplot_ttj_qcd_control noplot_vv_qcd_control noplot_wj_ss".split()]))
 				if channel == "em":
 					config.setdefault("qcd_extrapolation_factors_ss_os", []).append(2.0 + (0.0 if not "os" in exclude_cuts else 1.0))
 				elif channel == "et":
@@ -1756,9 +1756,6 @@ class Samples(samples.SamplesBase):
 								"noplot_vv_"+estimation_type,
 								nick_suffix=nick_suffix
 						)
-					import pprint
-					pprint.pprint(config)
-					#sys.exit()
 					if not "EstimateQcd" in config.get("analysis_modules", []):
 						config.setdefault("analysis_modules", []).append("EstimateQcd")
 					config.setdefault("qcd_shape_nicks", []).append("qcd"+nick_suffix)

--- a/python/plotting/modules/analysis_modules/estimateqcd.py
+++ b/python/plotting/modules/analysis_modules/estimateqcd.py
@@ -22,14 +22,13 @@ class EstimateQcd(estimatebase.EstimateBase):
 		super(EstimateQcd, self).modify_argument_parser(parser, args)
 		
 		self.estimate_qcd_options = parser.add_argument_group("QCD estimation options")
-		self.estimate_qcd_options.add_argument("--qcd-data-shape-nicks", nargs="+", default=["qcd"],
+		self.estimate_qcd_options.add_argument("--qcd-shape-nicks", nargs="+",
 				help="Nicks for histogram to plot. [Default: %(default)s]")
-		self.estimate_qcd_options.add_argument("--qcd-data-yield-nicks", nargs="+", default=["noplot_data_qcd_yield"],
+		self.estimate_qcd_options.add_argument("--qcd-yield-nicks", nargs="+",
 				help="Nicks for histogram containing the yield in data with the final selection that is then scaled. [Default: %(default)s]")
-		self.estimate_qcd_options.add_argument("--qcd-data-control-nicks", nargs="+", default=["noplot_data_qcd_control"],
-				help="Nicks for histogram to plot. [Default: %(default)s]")
-		self.estimate_qcd_options.add_argument("--qcd-data-substract-nicks", nargs="+",
-				default=["noplot_ztt_mc_qcd_control noplot_zll_qcd_control noplot_ttj_qcd_control noplot_vv_qcd_control noplot_wj_ss"],
+		self.estimate_qcd_options.add_argument("--qcd-shape-subtract-nicks", nargs="+",
+				help="Nicks for histogram to be subtracted from the shape. [Default: %(default)s]")
+		self.estimate_qcd_options.add_argument("--qcd-yield-subtract-nicks", nargs="+",
 				help="Nicks for control region histogram to substract from data (whitespace separated). [Default: %(default)s]")
 		self.estimate_qcd_options.add_argument("--qcd-extrapolation-factors-ss-os", nargs="+", type=float, default=[1.06],
 				help="Extrapolation factors of OS/SS yields. [Default: %(default)s]")
@@ -41,10 +40,11 @@ class EstimateQcd(estimatebase.EstimateBase):
 	def prepare_args(self, parser, plotData):
 		super(EstimateQcd, self).prepare_args(parser, plotData)
 		
-		self._plotdict_keys = ["qcd_data_shape_nicks", "qcd_data_yield_nicks", "qcd_data_control_nicks", "qcd_data_substract_nicks", "qcd_extrapolation_factors_ss_os", "qcd_subtract_shape"]
+		self._plotdict_keys = ["qcd_shape_nicks", "qcd_yield_nicks", "qcd_yield_subtract_nicks", "qcd_shape_subtract_nicks", "qcd_extrapolation_factors_ss_os"]
 		self.prepare_list_args(plotData, self._plotdict_keys)
-		
-		plotData.plotdict["qcd_data_substract_nicks"] = [nicks.split() for nicks in plotData.plotdict["qcd_data_substract_nicks"]]
+
+		plotData.plotdict["qcd_shape_subtract_nicks"] = [nicks.split() for nicks in plotData.plotdict["qcd_shape_subtract_nicks"]]	
+		plotData.plotdict["qcd_yield_subtract_nicks"] = [nicks.split() for nicks in plotData.plotdict["qcd_yield_subtract_nicks"]]	
 		
 		# make sure that all necessary histograms are available
 		for nicks in zip(*[plotData.plotdict[key] for key in self._plotdict_keys]):
@@ -54,49 +54,35 @@ class EstimateQcd(estimatebase.EstimateBase):
 				elif (not isinstance(nick, float) and not isinstance(nick, bool)):
 					for subnick in nick:
 						assert isinstance(plotData.plotdict["root_objects"].get(subnick), ROOT.TH1)
-		
-		#if any(plotData.plotdict["qcd_subtract_shape"]):
-			#log.warning("Shape substraction for QCD estimation is currently not supported! The calculations are instead done on the yields.")
 	
 	def run(self, plotData=None):
 		super(EstimateQcd, self).run(plotData)
 		
-		for qcd_data_shape_nick, qcd_data_yield_nick, qcd_data_control_nick, qcd_data_substract_nicks, qcd_extrapolation_factor_ss_os, qcd_subtract_shape in zip(*[plotData.plotdict[key] for key in self._plotdict_keys]):
+		for qcd_shape_nick, qcd_yield_nick, qcd_yield_subtract_nicks, qcd_shape_subtract_nicks, qcd_extrapolation_factor_ss_os in zip(*[plotData.plotdict[key] for key in self._plotdict_keys]):
 			
-			yield_data_control = tools.PoissonYield(plotData.plotdict["root_objects"][qcd_data_control_nick])()
-			yield_qcd_control = yield_data_control
-			for nick in qcd_data_substract_nicks:
-				yield_bkg_control = tools.PoissonYield(plotData.plotdict["root_objects"][nick])()
-				if nick in plotData.metadata:
-					yield_bkg_control = uncertainties.ufloat(
-							plotData.metadata[nick].get("yield", yield_bkg_control.nominal_value),
-							plotData.metadata[nick].get("yield_unc", yield_bkg_control.std_dev)
-					)
-				yield_qcd_control -= yield_bkg_control
-				
-				if qcd_subtract_shape:
-					plotData.plotdict["root_objects"][qcd_data_control_nick].Add(plotData.plotdict["root_objects"][nick], -1.0/plotData.plotdict["qcd_scale_factor"])
+			yield_qcd = tools.PoissonYield(plotData.plotdict["root_objects"][qcd_yield_nick])()
+			# estimate the QCD yield
+			# print "yield qcd total: " + str(yield_qcd)
+			for nick in qcd_yield_subtract_nicks:
+				yield_bkg = tools.PoissonYield(plotData.plotdict["root_objects"][nick])()
+				#print "minus " + nick + "  " + str(yield_bkg)	
+				yield_qcd -= yield_bkg
+			yield_qcd = max(0.0, yield_qcd)
+			if(yield_qcd == 0.0):
+				log.warning("QCD yield is 0!")
+			#  QCD shape
 			
-			if qcd_subtract_shape:
-				plotData.plotdict["root_objects"][qcd_data_shape_nick] = plotData.plotdict["root_objects"][qcd_data_control_nick]
+			#print "shape total: " + str(tools.PoissonYield(plotData.plotdict["root_objects"][qcd_shape_nick])())
+			for nick in qcd_shape_subtract_nicks:
+				#print "\t minus " + nick + " " + str(tools.PoissonYield(plotData.plotdict["root_objects"][nick])())
+				plotData.plotdict["root_objects"][qcd_shape_nick].Add(plotData.plotdict["root_objects"][nick], -1.0/plotData.plotdict["qcd_scale_factor"])
 			
-			yield_qcd_control = max(0.0, yield_qcd_control)
-			
-			scale_factor = yield_qcd_control * qcd_extrapolation_factor_ss_os
-			if yield_data_control != 0.0:
-				scale_factor /= yield_data_control
-			
-			final_yield = tools.PoissonYield(plotData.plotdict["root_objects"][qcd_data_yield_nick])() * scale_factor
-			log.debug("Relative statistical uncertainty of the yield for process QCD (nick \"{nick}\") is {unc}.".format(nick=qcd_data_shape_nick, unc=final_yield.std_dev/final_yield.nominal_value if final_yield.nominal_value != 0.0 else 0.0))
-			
-			plotData.metadata[qcd_data_shape_nick] = {
-				"yield" : final_yield.nominal_value,
-				"yield_unc" : final_yield.std_dev,
-				"yield_unc_rel" : abs(final_yield.std_dev/final_yield.nominal_value if final_yield.nominal_value != 0.0 else 0.0),
-			}
-			
-			integral_shape = tools.PoissonYield(plotData.plotdict["root_objects"][qcd_data_shape_nick])()
-			if integral_shape != 0.0:
-				scale_factor = final_yield / integral_shape
-				log.debug("Scale factor for process QCD (nick \"{nick}\") is {scale_factor}.".format(nick=qcd_data_shape_nick, scale_factor=scale_factor))
-				plotData.plotdict["root_objects"][qcd_data_shape_nick].Scale(scale_factor.nominal_value)
+			shape_yield = tools.PoissonYield(plotData.plotdict["root_objects"][qcd_shape_nick])()
+			if shape_yield != 0.0:
+				scale_factor = yield_qcd / shape_yield * qcd_extrapolation_factor_ss_os
+			#log.debug("Relative statistical uncertainty of the yield for process QCD (nick \"{nick}\") is {unc}.".format(nick=qcd_data_shape_nick, unc=final_yield.std_dev/final_yield.nominal_value if final_yield.nominal_value != 0.0 else 0.0))
+			plotData.plotdict["root_objects"][qcd_shape_nick].Scale(scale_factor.nominal_value)
+			#print "QCD em estimation summary"
+			#print "scale factor : " + str(scale_factor)
+			#print "shape_yield :"  + str(shape_yield)
+			#print "yield_qcd :" + str(yield_qcd)


### PR DESCRIPTION
I would like to update the EstimateQCD module so that separate yield and shape estimation is possible.

This affects the classic QCD estimation and newKIT.

The behaviour should be the same for inclusive categories. I checked for inclusive plots and the control plots did indeed look the same.

If no one has objections, I will merge tomorrow.