### PR TITLE
HttValidElectronsProducer refactored

### DIFF
--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -6,7 +6,12 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : "mvageneralpusposespring16tight",
+	"ElectronIDType" : {
+		"nick" : {
+			"default" : "mvageneralpurposespring16tight",
+			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15tight"
+		}
+	},
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -10,25 +10,25 @@
 	"ElectronIDName" : {
 		"nick" : {
 			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",
-			"(Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
 		}
 	},
 	"ElectronMvaIDCutEB1" : {
 		"nick" : {
 			"default" : 0.941,
-			"(Run2015|Fall15MiniAODv2)" : 0.967083
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.967083
 		}
 	},
 	"ElectronMvaIDCutEB2" : {
 		"nick" : {
 			"default" : 0.899,
-			"(Run2015|Fall15MiniAODv2)" : 0.929117
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.929117
 		}
 	},
 	"ElectronMvaIDCutEE" : {
 		"nick" : {
 			"default" : 0.758,
-			"(Run2015|Fall15MiniAODv2)" : 0.726311
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.726311
 		}
 	},
 	"ElectronIDList" : {
@@ -40,7 +40,7 @@
 				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium",
 				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"
 			],
-			"(Run2015|Fall15MiniAODv2)" : [
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : [
 				"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -12,6 +12,30 @@
 			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15tight"
 		}
 	},
+	"ElectronIDName" : {
+		"nick" : {
+			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",
+			"(Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
+		}
+	},
+	"ElectronMvaIDCutEB1" : {
+		"nick" : {
+			"default" : 0.941,
+			"(Run2015|Fall15MiniAODv2)" : 0.967083
+		}
+	},
+	"ElectronMvaIDCutEB2" : {
+		"nick" : {
+			"default" : 0.899,
+			"(Run2015|Fall15MiniAODv2)" : 0.929117
+		}
+	},
+	"ElectronMvaIDCutEE" : {
+		"nick" : {
+			"default" : 0.758,
+			"(Run2015|Fall15MiniAODv2)" : 0.726311
+		}
+	},
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -31,6 +31,24 @@
 			"(Run2015|Fall15MiniAODv2)" : 0.726311
 		}
 	},
+	"ElectronIDList" : {
+		"nick" : {
+			"default" : [
+				"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",
+				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto",
+				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose",
+				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium",
+				"egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"
+			],
+			"(Run2015|Fall15MiniAODv2)" : [
+				"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+				"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+			]
+		}
+	},
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -6,7 +6,7 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDType" : "mvageneralpusposespring16tight",
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsElectronID.json
@@ -6,12 +6,7 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : {
-		"nick" : {
-			"default" : "mvageneralpurposespring16tight",
-			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15tight"
-		}
-	},
+	"ElectronIDType" : "mvabased2015andlater",
 	"ElectronIDName" : {
 		"nick" : {
 			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
@@ -6,12 +6,7 @@
 	"LooseElectronReco" : "mvanontrig",
 
 	"LooseElectronID" : "user",
-	"LooseElectronIDType" : {
-		"nick" : {
-			"default" : "mvageneralpurposespring16loose",
-			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15loose"
-		}
-	},
+	"LooseElectronIDType" : "mvabased2015andlater",
 	"LooseElectronIDName" : {
 		"nick" : {
 			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
@@ -12,6 +12,30 @@
 			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15loose"
 		}
 	},
+	"LooseElectronIDName" : {
+		"nick" : {
+			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",
+			"(Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
+		}
+	},
+	"LooseElectronMvaIDCutEB1" : {
+		"nick" : {
+			"default" : 0.837,
+			"(Run2015|Fall15MiniAODv2)" : 0.913286
+		}
+	},
+	"LooseElectronMvaIDCutEB2" : {
+		"nick" : {
+			"default" : 0.715,
+			"(Run2015|Fall15MiniAODv2)" : 0.805013
+		}
+	},
+	"LooseElectronMvaIDCutEE" : {
+		"nick" : {
+			"default" : 0.357,
+			"(Run2015|Fall15MiniAODv2)" : 0.358969
+		}
+	},
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
@@ -10,25 +10,25 @@
 	"LooseElectronIDName" : {
 		"nick" : {
 			"default" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values",
-			"(Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"
 		}
 	},
 	"LooseElectronMvaIDCutEB1" : {
 		"nick" : {
 			"default" : 0.837,
-			"(Run2015|Fall15MiniAODv2)" : 0.913286
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.913286
 		}
 	},
 	"LooseElectronMvaIDCutEB2" : {
 		"nick" : {
 			"default" : 0.715,
-			"(Run2015|Fall15MiniAODv2)" : 0.805013
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.805013
 		}
 	},
 	"LooseElectronMvaIDCutEE" : {
 		"nick" : {
 			"default" : 0.357,
-			"(Run2015|Fall15MiniAODv2)" : 0.358969
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : 0.358969
 		}
 	},
 

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsLooseElectronID.json
@@ -6,7 +6,12 @@
 	"LooseElectronReco" : "mvanontrig",
 
 	"LooseElectronID" : "user",
-	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDType" : {
+		"nick" : {
+			"default" : "mvageneralpurposespring16loose",
+			"(Run2015|Fall15MiniAODv2)" : "mvanontrigspring15loose"
+		}
+	},
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
@@ -6,7 +6,12 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDType" : {
+		"nick" : {
+			"default" : "summer16cutbasedveto",
+			"(Run2015|Fall15MiniAODv2)" : "spring15cutbasedveto"
+		}
+	},
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
@@ -12,6 +12,12 @@
 			"(Run2015|Fall15MiniAODv2)" : "spring15cutbasedveto"
 		}
 	},
+	"VetoElectronIDName" : {
+		"nick" : {
+			"default" : "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto",
+			"(Run2015|Fall15MiniAODv2)" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"
+		}
+	},
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
@@ -6,12 +6,7 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : {
-		"nick" : {
-			"default" : "summer16cutbasedveto",
-			"(Run2015|Fall15MiniAODv2)" : "spring15cutbasedveto"
-		}
-	},
+	"VetoElectronIDType" : "cutbased2015andlater",
 	"VetoElectronIDName" : {
 		"nick" : {
 			"default" : "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto",

--- a/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2Analysis/Includes/settingsVetoElectronID.json
@@ -10,7 +10,7 @@
 	"VetoElectronIDName" : {
 		"nick" : {
 			"default" : "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto",
-			"(Run2015|Fall15MiniAODv2)" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"
+			"(Run2016|Spring16|Run2015|Fall15MiniAODv2)" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"
 		}
 	},
 

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
@@ -6,7 +6,7 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDType" : "mvabased2015andlater",
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
@@ -11,6 +11,13 @@
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,
 	"ElectronMvaIDCutEE" : 0.726311,
+	"ElectronIDList" : [
+		"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+	],
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsElectronID.json
@@ -7,6 +7,10 @@
 	
 	"ElectronID" : "user",
 	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"ElectronMvaIDCutEB1" : 0.967083,
+	"ElectronMvaIDCutEB2" : 0.929117,
+	"ElectronMvaIDCutEE" : 0.726311,
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsLooseElectronID.json
@@ -6,7 +6,7 @@
 	"LooseElectronReco" : "mvanontrig",
 
 	"LooseElectronID" : "user",
-	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDType" : "mvabased2015andlater",
 	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"LooseElectronMvaIDCutEB1" : 0.913286,
 	"LooseElectronMvaIDCutEB2" : 0.805013,

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsLooseElectronID.json
@@ -7,6 +7,10 @@
 
 	"LooseElectronID" : "user",
 	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"LooseElectronMvaIDCutEB1" : 0.913286,
+	"LooseElectronMvaIDCutEB2" : 0.805013,
+	"LooseElectronMvaIDCutEE" : 0.358969,
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsVetoElectronID.json
@@ -6,7 +6,7 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDType" : "cutbased2015andlater",
 	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",

--- a/data/ArtusConfigs/Run2MSSM/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM/Includes/settingsVetoElectronID.json
@@ -7,6 +7,7 @@
 
 	"VetoElectronID" : "user",
 	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
@@ -6,7 +6,7 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDType" : "mvabased2015andlater",
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
@@ -11,6 +11,13 @@
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,
 	"ElectronMvaIDCutEE" : 0.726311,
+	"ElectronIDList" : [
+		"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+	],
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsElectronID.json
@@ -7,6 +7,10 @@
 	
 	"ElectronID" : "user",
 	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"ElectronMvaIDCutEB1" : 0.967083,
+	"ElectronMvaIDCutEB2" : 0.929117,
+	"ElectronMvaIDCutEE" : 0.726311,
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsLooseElectronID.json
@@ -6,7 +6,7 @@
 	"LooseElectronReco" : "mvanontrig",
 
 	"LooseElectronID" : "user",
-	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDType" : "mvabased2015andlater",
 	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"LooseElectronMvaIDCutEB1" : 0.913286,
 	"LooseElectronMvaIDCutEB2" : 0.805013,

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsLooseElectronID.json
@@ -7,6 +7,10 @@
 
 	"LooseElectronID" : "user",
 	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"LooseElectronMvaIDCutEB1" : 0.913286,
+	"LooseElectronMvaIDCutEB2" : 0.805013,
+	"LooseElectronMvaIDCutEE" : 0.358969,
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsVetoElectronID.json
@@ -6,7 +6,7 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDType" : "cutbased2015andlater",
 	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",

--- a/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MSSM_2015/Includes/settingsVetoElectronID.json
@@ -7,6 +7,7 @@
 
 	"VetoElectronID" : "user",
 	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
@@ -6,7 +6,7 @@
 	"ElectronReco" : "mvanontrig",
 	
 	"ElectronID" : "user",
-	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDType" : "mvabased2015andlater",
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
@@ -11,6 +11,13 @@
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,
 	"ElectronMvaIDCutEE" : 0.726311,
+	"ElectronIDList" : [
+		"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+	],
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsElectronID.json
@@ -7,6 +7,10 @@
 	
 	"ElectronID" : "user",
 	"ElectronIDType" : "mvanontrigspring15tight",
+	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"ElectronMvaIDCutEB1" : 0.967083,
+	"ElectronMvaIDCutEB2" : 0.929117,
+	"ElectronMvaIDCutEE" : 0.726311,
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsLooseElectronID.json
@@ -6,7 +6,7 @@
 	"LooseElectronReco" : "mvanontrig",
 
 	"LooseElectronID" : "user",
-	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDType" : "mvabased2015andlater",
 	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"LooseElectronMvaIDCutEB1" : 0.913286,
 	"LooseElectronMvaIDCutEB2" : 0.805013,

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsLooseElectronID.json
@@ -7,6 +7,10 @@
 
 	"LooseElectronID" : "user",
 	"LooseElectronIDType" : "mvanontrigspring15loose",
+	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"LooseElectronMvaIDCutEB1" : 0.913286,
+	"LooseElectronMvaIDCutEB2" : 0.805013,
+	"LooseElectronMvaIDCutEE" : 0.358969,
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsVetoElectronID.json
@@ -6,7 +6,7 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDType" : "cutbased2015andlater",
 	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",

--- a/data/ArtusConfigs/Run2MvaStudies/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Run2MvaStudies/Includes/settingsVetoElectronID.json
@@ -7,6 +7,7 @@
 
 	"VetoElectronID" : "user",
 	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
@@ -14,6 +14,7 @@
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,
+	"ElectronMvaIDCutEE" : 0.726311,
 	"ElectronIDList" : [
 		"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
@@ -11,6 +11,10 @@
 			"(Spring15|Fall15|Spring16)" : "mvanontrigspring15tight"
 		}
 	},
+	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"ElectronMvaIDCutEB1" : 0.967083,
+	"ElectronMvaIDCutEB2" : 0.929117,
+	"ElectronMvaIDCutEE" : 0.726311,
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
@@ -8,7 +8,7 @@
 	"ElectronIDType" : {
 		"nick" : {
 			"default" : "none",
-			"(Spring15|Fall15|Spring16)" : "mvanontrigspring15tight"
+			"(Spring15|Fall15|Spring16)" : "mvabased2015andlater"
 		}
 	},
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsElectronID.json
@@ -14,7 +14,13 @@
 	"ElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
 	"ElectronMvaIDCutEB1" : 0.967083,
 	"ElectronMvaIDCutEB2" : 0.929117,
-	"ElectronMvaIDCutEE" : 0.726311,
+	"ElectronIDList" : [
+		"electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium",
+		"egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+	],
 	
 	"ElectronIsoType" : "user",
 	"ElectronIso" : "none",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsLooseElectronID.json
@@ -9,7 +9,7 @@
 	"LooseElectronIDType" : {
 		"nick" : {
 			"default" : "none",
-			"(Spring15|Fall15|Spring16)" : "mvanontrigspring15loose"
+			"(Spring15|Fall15|Spring16)" : "mvabased2015andlater"
 		}
 	},
 	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsLooseElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsLooseElectronID.json
@@ -12,6 +12,10 @@
 			"(Spring15|Fall15|Spring16)" : "mvanontrigspring15loose"
 		}
 	},
+	"LooseElectronIDName" : "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values",
+	"LooseElectronMvaIDCutEB1" : 0.913286,
+	"LooseElectronMvaIDCutEB2" : 0.805013,
+	"LooseElectronMvaIDCutEE" : 0.358969,
 
 	"LooseElectronIsoType" : "user",
 	"LooseElectronIso" : "none",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsVetoElectronID.json
@@ -6,7 +6,7 @@
 	"VetoElectronReco" : "none",
 
 	"VetoElectronID" : "user",
-	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDType" : "cutbased2015andlater",
 	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",

--- a/data/ArtusConfigs/Sync13TeV/Includes/settingsVetoElectronID.json
+++ b/data/ArtusConfigs/Sync13TeV/Includes/settingsVetoElectronID.json
@@ -7,6 +7,7 @@
 
 	"VetoElectronID" : "user",
 	"VetoElectronIDType" : "spring15cutbasedveto",
+	"VetoElectronIDName" : "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto",
 
 	"VetoElectronIsoType" : "user",
 	"VetoElectronIso" : "none",

--- a/interface/HttSettings.h
+++ b/interface/HttSettings.h
@@ -64,6 +64,10 @@ public:
 	IMPL_SETTING_STRINGLIST_DEFAULT(MuonTauFakeRateHistograms, {});
 
 	IMPL_SETTING(std::string, ElectronIDType);
+	IMPL_SETTING_DEFAULT(std::string, ElectronIDName, "");
+	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEB1, -1.0);
+	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEB2, -1.0);
+	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEE, -1.0);
 
 	IMPL_SETTING_DEFAULT(float, ElectronChargedIsoVetoConeSizeEB, 0.0);
 	IMPL_SETTING_DEFAULT(float, ElectronChargedIsoVetoConeSizeEE, 0.0);
@@ -109,6 +113,10 @@ public:
 
 	IMPL_SETTING(std::string, LooseElectronID);
 	IMPL_SETTING(std::string, LooseElectronIDType);
+	IMPL_SETTING_DEFAULT(std::string, LooseElectronIDName, "");
+	IMPL_SETTING_DEFAULT(float, LooseElectronMvaIDCutEB1, -1.0);
+	IMPL_SETTING_DEFAULT(float, LooseElectronMvaIDCutEB2, -1.0);
+	IMPL_SETTING_DEFAULT(float, LooseElectronMvaIDCutEE, -1.0);
 	IMPL_SETTING(std::string, LooseElectronReco);
 	IMPL_SETTING(std::string, LooseMuonID);
 
@@ -139,6 +147,10 @@ public:
 
 	IMPL_SETTING(std::string, VetoElectronID);
 	IMPL_SETTING(std::string, VetoElectronIDType);
+	IMPL_SETTING_DEFAULT(std::string, VetoElectronIDName, "");
+	IMPL_SETTING_DEFAULT(float, VetoElectronMvaIDCutEB1, -1.0);
+	IMPL_SETTING_DEFAULT(float, VetoElectronMvaIDCutEB2, -1.0);
+	IMPL_SETTING_DEFAULT(float, VetoElectronMvaIDCutEE, -1.0);
 	IMPL_SETTING(std::string, VetoElectronReco);
 	IMPL_SETTING(std::string, VetoMuonID);
 

--- a/interface/HttSettings.h
+++ b/interface/HttSettings.h
@@ -65,6 +65,7 @@ public:
 
 	IMPL_SETTING(std::string, ElectronIDType);
 	IMPL_SETTING_DEFAULT(std::string, ElectronIDName, "");
+	IMPL_SETTING_STRINGLIST_DEFAULT(ElectronIDList, {});
 	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEB1, -1.0);
 	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEB2, -1.0);
 	IMPL_SETTING_DEFAULT(float, ElectronMvaIDCutEE, -1.0);

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -58,6 +58,10 @@ public:
 		SPRING15CUTBASEDVETO = 13,
 		MVANONTRIGSPRING15LOOSE = 14,
 		MVANONTRIGSPRING15TIGHT = 15,
+		SUMMER16CUTBASEDLOOSE = 16,
+		SUMMER16CUTBASEDMEDIUM = 17,
+		SUMMER16CUTBASEDTIGHT = 18,
+		SUMMER16CUTBASEDVETO = 19,
 	};
 	enum class WorkingPoint : int
 	{
@@ -84,6 +88,10 @@ public:
 		else if (electronIDType == "spring15cutbasedveto") return ElectronIDType::SPRING15CUTBASEDVETO;
 		else if (electronIDType == "mvanontrigspring15loose") return ElectronIDType::MVANONTRIGSPRING15LOOSE;
 		else if (electronIDType == "mvanontrigspring15tight") return ElectronIDType::MVANONTRIGSPRING15TIGHT;
+		else if (electronIDType == "summer16cutbasedloose") return ElectronIDType::SUMMER16CUTBASEDLOOSE;
+		else if (electronIDType == "summer16cutbasedmedium") return ElectronIDType::SUMMER16CUTBASEDMEDIUM;
+		else if (electronIDType == "summer16cutbasedtight") return ElectronIDType::SUMMER16CUTBASEDTIGHT;
+		else if (electronIDType == "summer16cutbasedveto") return ElectronIDType::SUMMER16CUTBASEDVETO;
 		else if (electronIDType == "none") return ElectronIDType::NONE;
 		else
 			LOG(FATAL) << "Could not find ElectronID " << electronIDType << "! If you want the HttValidElectronsProducer to use no special ID, use \"none\" as argument."<< std::endl;
@@ -157,6 +165,7 @@ private:
 	bool IsMVANonTrigElectronHttSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsCutBasedPhys14(KElectron* electron, event_type const& event, WorkingPoint wp) const;
 	bool IsCutBasedSpring15(KElectron* electron, event_type const& event, WorkingPoint wp) const;
+	bool IsCutBasedSummer16(KElectron* electron, event_type const& event, WorkingPoint wp) const;
 	bool IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVANonTrigSpring15(KElectron* electron, event_type const& event, bool tightID) const;
 	std::string ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const;

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -42,7 +42,6 @@ public:
 	typedef typename HttTypes::product_type product_type;
 	typedef typename HttTypes::setting_type setting_type;
 
-	// This is not really needed for 2015 and later any longer
 	enum class ElectronIDType : int
 	{
 		INVALID = -2,
@@ -57,18 +56,8 @@ public:
 		PHYS14CUTBASEDVETO = 7,
 		MVANONTRIGPHYS14LOOSE = 8,
 		MVANONTRIGPHYS14TIGHT = 9,
-		SPRING15CUTBASEDLOOSE = 10,
-		SPRING15CUTBASEDMEDIUM = 11,
-		SPRING15CUTBASEDTIGHT = 12,
-		SPRING15CUTBASEDVETO = 13,
-		MVANONTRIGSPRING15LOOSE = 14,
-		MVANONTRIGSPRING15TIGHT = 15,
-		SUMMER16CUTBASEDLOOSE = 16,
-		SUMMER16CUTBASEDMEDIUM = 17,
-		SUMMER16CUTBASEDTIGHT = 18,
-		SUMMER16CUTBASEDVETO = 19,
-		MVAGENERALPURPOSESPRING16LOOSE = 20,
-		MVAGENERALPURPOSESPRING16TIGHT = 21
+		CUTBASED2015ANDLATER = 10,
+		MVABASED2015ANDLATER = 11
 	};
 	enum class WorkingPoint : int
 	{
@@ -89,18 +78,8 @@ public:
 		else if (electronIDType == "phys14cutbasedveto") return ElectronIDType::PHYS14CUTBASEDVETO;
 		else if (electronIDType == "mvanontrigphys14loose") return ElectronIDType::MVANONTRIGPHYS14LOOSE;
 		else if (electronIDType == "mvanontrigphys14tight") return ElectronIDType::MVANONTRIGPHYS14TIGHT;
-		else if (electronIDType == "spring15cutbasedloose") return ElectronIDType::SPRING15CUTBASEDLOOSE;
-		else if (electronIDType == "spring15cutbasedmedium") return ElectronIDType::SPRING15CUTBASEDMEDIUM;
-		else if (electronIDType == "spring15cutbasedtight") return ElectronIDType::SPRING15CUTBASEDTIGHT;
-		else if (electronIDType == "spring15cutbasedveto") return ElectronIDType::SPRING15CUTBASEDVETO;
-		else if (electronIDType == "mvanontrigspring15loose") return ElectronIDType::MVANONTRIGSPRING15LOOSE;
-		else if (electronIDType == "mvanontrigspring15tight") return ElectronIDType::MVANONTRIGSPRING15TIGHT;
-		else if (electronIDType == "summer16cutbasedloose") return ElectronIDType::SUMMER16CUTBASEDLOOSE;
-		else if (electronIDType == "summer16cutbasedmedium") return ElectronIDType::SUMMER16CUTBASEDMEDIUM;
-		else if (electronIDType == "summer16cutbasedtight") return ElectronIDType::SUMMER16CUTBASEDTIGHT;
-		else if (electronIDType == "summer16cutbasedveto") return ElectronIDType::SUMMER16CUTBASEDVETO;
-		else if (electronIDType == "mvageneralpurposespring16loose") return ElectronIDType::MVAGENERALPURPOSESPRING16LOOSE;
-		else if (electronIDType == "mvageneralpurposespring16tight") return ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT;
+		else if (electronIDType == "cutbased2015andlater") return ElectronIDType::CUTBASED2015ANDLATER;
+		else if (electronIDType == "mvabased2015andlater") return ElectronIDType::MVABASED2015ANDLATER;
 		else if (electronIDType == "none") return ElectronIDType::NONE;
 		else
 			LOG(FATAL) << "Could not find ElectronID " << electronIDType << "! If you want the HttValidElectronsProducer to use no special ID, use \"none\" as argument."<< std::endl;

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -31,6 +31,7 @@
    - ElectronIsoPtSumOverPtLowerThresholdEE
    - ElectronIsoPtSumOverPtUpperThresholdEB
    - ElectronIsoPtSumOverPtUpperThresholdEE
+   - ElectronIDList (default given)
 */
 
 class HttValidElectronsProducer: public ValidElectronsProducer<HttTypes>
@@ -50,21 +51,8 @@ public:
 		SUMMER2013TIGHT = 1,
 		SUMMER2013TTHTIGHT = 2,
 		SUMMER2013TTHLOOSE = 3,
-		PHYS14CUTBASEDLOOSE = 4,
-		PHYS14CUTBASEDMEDIUM = 5,
-		PHYS14CUTBASEDTIGHT = 6,
-		PHYS14CUTBASEDVETO = 7,
-		MVANONTRIGPHYS14LOOSE = 8,
-		MVANONTRIGPHYS14TIGHT = 9,
-		CUTBASED2015ANDLATER = 10,
-		MVABASED2015ANDLATER = 11
-	};
-	enum class WorkingPoint : int
-	{
-		LOOSE = 0,
-		MEDIUM = 1,
-		TIGHT = 2,
-		VETO = 3,
+		CUTBASED2015ANDLATER = 4,
+		MVABASED2015ANDLATER = 5
 	};
 	static ElectronIDType ToElectronIDType(std::string const& electronIDType)
 	{
@@ -72,12 +60,6 @@ public:
 		else if (electronIDType == "summer2013tight") return ElectronIDType::SUMMER2013TIGHT;
 		else if (electronIDType == "summer2013tthloose") return ElectronIDType::SUMMER2013TTHLOOSE;
 		else if (electronIDType == "summer2013tthtight") return ElectronIDType::SUMMER2013TTHTIGHT;
-		else if (electronIDType == "phys14cutbasedloose") return ElectronIDType::PHYS14CUTBASEDLOOSE;
-		else if (electronIDType == "phys14cutbasedmedium") return ElectronIDType::PHYS14CUTBASEDMEDIUM;
-		else if (electronIDType == "phys14cutbasedtight") return ElectronIDType::PHYS14CUTBASEDTIGHT;
-		else if (electronIDType == "phys14cutbasedveto") return ElectronIDType::PHYS14CUTBASEDVETO;
-		else if (electronIDType == "mvanontrigphys14loose") return ElectronIDType::MVANONTRIGPHYS14LOOSE;
-		else if (electronIDType == "mvanontrigphys14tight") return ElectronIDType::MVANONTRIGPHYS14TIGHT;
 		else if (electronIDType == "cutbased2015andlater") return ElectronIDType::CUTBASED2015ANDLATER;
 		else if (electronIDType == "mvabased2015andlater") return ElectronIDType::MVABASED2015ANDLATER;
 		else if (electronIDType == "none") return ElectronIDType::NONE;
@@ -171,12 +153,8 @@ private:
 
 	bool IsMVATrigElectronTTHSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVANonTrigElectronHttSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
-	bool IsCutBasedPhys14(KElectron* electron, event_type const& event, WorkingPoint wp) const;
 	bool IsCutBased(KElectron* electron, event_type const& event, const std::string &idName) const;
-	bool IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVABased(KElectron* electron, event_type const& event, const std::string &idName) const;
-	std::string ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const;
-	std::string ChooseMvaNonTrigId(const KElectronMetadata *meta) const;
 	bool CheckElectronMetadata(const KElectronMetadata *meta, std::string idName, bool &checkedAlready) const;
 	bool CheckElectronMetadata(const KElectronMetadata *meta, std::vector<std::string> idNames, bool &checkedAlready) const;
 };

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -117,7 +117,8 @@ public:
 			float (setting_type::*GetElectronIsoPtSumOverPtUpperThresholdEB)(void) const=&setting_type::GetElectronIsoPtSumOverPtUpperThresholdEB,
 			float (setting_type::*GetElectronIsoPtSumOverPtUpperThresholdEE)(void) const=&setting_type::GetElectronIsoPtSumOverPtUpperThresholdEE,
 			float (setting_type::*GetElectronTrackDxyCut)(void) const=&setting_type::GetElectronTrackDxyCut,
-			float (setting_type::*GetElectronTrackDzCut)(void) const=&setting_type::GetElectronTrackDzCut
+			float (setting_type::*GetElectronTrackDzCut)(void) const=&setting_type::GetElectronTrackDzCut,
+			std::vector<std::string>& (setting_type::*GetElectronIDList)(void) const=&setting_type::GetElectronIDList
 	);
 
 	virtual void Init(setting_type const& settings) override;
@@ -154,20 +155,30 @@ private:
 	float (setting_type::*GetElectronIsoPtSumOverPtUpperThresholdEE)(void) const;
 	float (setting_type::*GetElectronTrackDxyCut)(void) const;
 	float (setting_type::*GetElectronTrackDzCut)(void) const;
+	std::vector<std::string>& (setting_type::*GetElectronIDList)(void) const;
 
 	ElectronIDType electronIDType;
 	
-	mutable bool checkedElectronMetadata;
+	mutable bool electronIDListInMetadata;
+	mutable bool electronIDInMetadata;
+
+	std::string electronIDName;
+	std::vector<std::string> electronIDList;
+
+	float electronMvaIDCutEB1;
+	float electronMvaIDCutEB2;
+	float electronMvaIDCutEE;
 
 	bool IsMVATrigElectronTTHSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVANonTrigElectronHttSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsCutBasedPhys14(KElectron* electron, event_type const& event, WorkingPoint wp) const;
-	bool IsCutBased(KElectron* electron, event_type const& event, setting_type const& settings) const;
+	bool IsCutBased(KElectron* electron, event_type const& event, const std::string &idName) const;
 	bool IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const;
-	bool IsMVABased(KElectron* electron, event_type const& event, setting_type const& settings) const;
+	bool IsMVABased(KElectron* electron, event_type const& event, const std::string &idName) const;
 	std::string ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const;
 	std::string ChooseMvaNonTrigId(const KElectronMetadata *meta) const;
 	bool CheckElectronMetadata(const KElectronMetadata *meta, std::string idName, bool &checkedAlready) const;
+	bool CheckElectronMetadata(const KElectronMetadata *meta, std::vector<std::string> idNames, bool &checkedAlready) const;
 };
 
 

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -62,6 +62,8 @@ public:
 		SUMMER16CUTBASEDMEDIUM = 17,
 		SUMMER16CUTBASEDTIGHT = 18,
 		SUMMER16CUTBASEDVETO = 19,
+		MVAGENERALPURPOSESPRING16LOOSE = 20,
+		MVAGENERALPURPOSESPRING16TIGHT = 21
 	};
 	enum class WorkingPoint : int
 	{
@@ -92,6 +94,8 @@ public:
 		else if (electronIDType == "summer16cutbasedmedium") return ElectronIDType::SUMMER16CUTBASEDMEDIUM;
 		else if (electronIDType == "summer16cutbasedtight") return ElectronIDType::SUMMER16CUTBASEDTIGHT;
 		else if (electronIDType == "summer16cutbasedveto") return ElectronIDType::SUMMER16CUTBASEDVETO;
+		else if (electronIDType == "mvageneralpurposespring16loose") return ElectronIDType::MVAGENERALPURPOSESPRING16LOOSE;
+		else if (electronIDType == "mvageneralpusposespring16tight") return ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT;
 		else if (electronIDType == "none") return ElectronIDType::NONE;
 		else
 			LOG(FATAL) << "Could not find ElectronID " << electronIDType << "! If you want the HttValidElectronsProducer to use no special ID, use \"none\" as argument."<< std::endl;
@@ -168,6 +172,7 @@ private:
 	bool IsCutBasedSummer16(KElectron* electron, event_type const& event, WorkingPoint wp) const;
 	bool IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVANonTrigSpring15(KElectron* electron, event_type const& event, bool tightID) const;
+	bool IsMVAGeneralPurposeSpring16(KElectron* electron, event_type const& event, bool tightID) const;
 	std::string ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const;
 	std::string ChooseMvaNonTrigId(const KElectronMetadata *meta) const;
 };

--- a/interface/Producers/HttValidElectronsProducer.h
+++ b/interface/Producers/HttValidElectronsProducer.h
@@ -11,6 +11,10 @@
    
    Required config tags in addtion to the ones of the base class:
    - ElectronIDType
+   - ElectronIDName (default given)
+   - ElectronMvaIDCutEB1 (default given)
+   - ElectronMvaIDCutEB2 (default given)
+   - ElectronMvaIDCutEE (default given)
    - ElectronChargedIsoVetoConeSizeEB (default given)
    - ElectronChargedIsoVetoConeSizeEE (default given)
    - ElectronNeutralIsoVetoConeSize (default given)
@@ -38,6 +42,7 @@ public:
 	typedef typename HttTypes::product_type product_type;
 	typedef typename HttTypes::setting_type setting_type;
 
+	// This is not really needed for 2015 and later any longer
 	enum class ElectronIDType : int
 	{
 		INVALID = -2,
@@ -95,7 +100,7 @@ public:
 		else if (electronIDType == "summer16cutbasedtight") return ElectronIDType::SUMMER16CUTBASEDTIGHT;
 		else if (electronIDType == "summer16cutbasedveto") return ElectronIDType::SUMMER16CUTBASEDVETO;
 		else if (electronIDType == "mvageneralpurposespring16loose") return ElectronIDType::MVAGENERALPURPOSESPRING16LOOSE;
-		else if (electronIDType == "mvageneralpusposespring16tight") return ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT;
+		else if (electronIDType == "mvageneralpurposespring16tight") return ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT;
 		else if (electronIDType == "none") return ElectronIDType::NONE;
 		else
 			LOG(FATAL) << "Could not find ElectronID " << electronIDType << "! If you want the HttValidElectronsProducer to use no special ID, use \"none\" as argument."<< std::endl;
@@ -107,6 +112,10 @@ public:
 			std::vector<KElectron*> product_type::*invalidElectrons=&product_type::m_invalidElectrons,
 			std::string (setting_type::*GetElectronID)(void) const=&setting_type::GetElectronID,
 			std::string (setting_type::*GetElectronIDType)(void) const=&setting_type::GetElectronIDType,
+			std::string (setting_type::*GetElectronIDName)(void) const=&setting_type::GetElectronIDName,
+			float (setting_type::*GetElectronMvaIDCutEB1)(void) const=&setting_type::GetElectronMvaIDCutEB1,
+			float (setting_type::*GetElectronMvaIDCutEB2)(void) const=&setting_type::GetElectronMvaIDCutEB2,
+			float (setting_type::*GetElectronMvaIDCutEE)(void) const=&setting_type::GetElectronMvaIDCutEE,
 			std::string (setting_type::*GetElectronIsoType)(void) const=&setting_type::GetElectronIsoType,
 			std::string (setting_type::*GetElectronIso)(void) const=&setting_type::GetElectronIso,
 			std::string (setting_type::*GetElectronReco)(void) const=&setting_type::GetElectronReco,
@@ -144,6 +153,10 @@ protected:
 
 private:
 	std::string (setting_type::*GetElectronIDType)(void) const;
+	std::string (setting_type::*GetElectronIDName)(void) const;
+	float (setting_type::*GetElectronMvaIDCutEB1)(void) const;
+	float (setting_type::*GetElectronMvaIDCutEB2)(void) const;
+	float (setting_type::*GetElectronMvaIDCutEE)(void) const;
 	float (setting_type::*GetElectronChargedIsoVetoConeSizeEB)(void) const;
 	float (setting_type::*GetElectronChargedIsoVetoConeSizeEE)(void) const;
 	float (setting_type::*GetElectronNeutralIsoVetoConeSize)(void) const;
@@ -165,16 +178,17 @@ private:
 
 	ElectronIDType electronIDType;
 	
+	mutable bool checkedElectronMetadata;
+
 	bool IsMVATrigElectronTTHSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsMVANonTrigElectronHttSummer2013(KElectron* electron, event_type const& event, bool tightID) const;
 	bool IsCutBasedPhys14(KElectron* electron, event_type const& event, WorkingPoint wp) const;
-	bool IsCutBasedSpring15(KElectron* electron, event_type const& event, WorkingPoint wp) const;
-	bool IsCutBasedSummer16(KElectron* electron, event_type const& event, WorkingPoint wp) const;
+	bool IsCutBased(KElectron* electron, event_type const& event, setting_type const& settings) const;
 	bool IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const;
-	bool IsMVANonTrigSpring15(KElectron* electron, event_type const& event, bool tightID) const;
-	bool IsMVAGeneralPurposeSpring16(KElectron* electron, event_type const& event, bool tightID) const;
+	bool IsMVABased(KElectron* electron, event_type const& event, setting_type const& settings) const;
 	std::string ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const;
 	std::string ChooseMvaNonTrigId(const KElectronMetadata *meta) const;
+	bool CheckElectronMetadata(const KElectronMetadata *meta, std::string idName, bool &checkedAlready) const;
 };
 
 
@@ -208,6 +222,10 @@ public:
 			std::vector<KElectron*> product_type::*invalidElectrons=&product_type::m_invalidLooseElectrons,
 			std::string (setting_type::*GetElectronID)(void) const=&setting_type::GetLooseElectronID,
 			std::string (setting_type::*GetElectronIDType)(void) const=&setting_type::GetLooseElectronIDType,
+			std::string (setting_type::*GetElectronIDName)(void) const=&setting_type::GetLooseElectronIDName,
+			float (setting_type::*GetElectronMvaIDCutEB1)(void) const=&setting_type::GetLooseElectronMvaIDCutEB1,
+			float (setting_type::*GetElectronMvaIDCutEB2)(void) const=&setting_type::GetLooseElectronMvaIDCutEB2,
+			float (setting_type::*GetElectronMvaIDCutEE)(void) const=&setting_type::GetLooseElectronMvaIDCutEE,
 			std::string (setting_type::*GetElectronIsoType)(void) const=&setting_type::GetLooseElectronIsoType,
 			std::string (setting_type::*GetElectronIso)(void) const=&setting_type::GetLooseElectronIso,
 			std::string (setting_type::*GetElectronReco)(void) const=&setting_type::GetLooseElectronReco,
@@ -266,6 +284,10 @@ public:
 			std::vector<KElectron*> product_type::*invalidElectrons=&product_type::m_invalidVetoElectrons,
 			std::string (setting_type::*GetElectronID)(void) const=&setting_type::GetVetoElectronID,
 			std::string (setting_type::*GetElectronIDType)(void) const=&setting_type::GetVetoElectronIDType,
+			std::string (setting_type::*GetElectronIDName)(void) const=&setting_type::GetVetoElectronIDName,
+			float (setting_type::*GetElectronMvaIDCutEB1)(void) const=&setting_type::GetVetoElectronMvaIDCutEB1,
+			float (setting_type::*GetElectronMvaIDCutEB2)(void) const=&setting_type::GetVetoElectronMvaIDCutEB2,
+			float (setting_type::*GetElectronMvaIDCutEE)(void) const=&setting_type::GetVetoElectronMvaIDCutEE,
 			std::string (setting_type::*GetElectronIsoType)(void) const=&setting_type::GetVetoElectronIsoType,
 			std::string (setting_type::*GetElectronIso)(void) const=&setting_type::GetVetoElectronIso,
 			std::string (setting_type::*GetElectronReco)(void) const=&setting_type::GetVetoElectronReco,

--- a/src/Producers/HttValidElectronsProducer.cc
+++ b/src/Producers/HttValidElectronsProducer.cc
@@ -174,6 +174,22 @@ bool HttValidElectronsProducer::AdditionalCriteria(KElectron* electron,
 		{
 			validElectron = validElectron && IsMVANonTrigSpring15(&(*electron), event, true);
 		}
+		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDLOOSE)
+		{
+			validElectron = validElectron && IsCutBasedSummer16(&(*electron), event, WorkingPoint::LOOSE);
+		}
+		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDMEDIUM)
+		{
+			validElectron = validElectron && IsCutBasedSummer16(&(*electron), event, WorkingPoint::MEDIUM);
+		}
+		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDTIGHT)
+		{
+			validElectron = validElectron && IsCutBasedSummer16(&(*electron), event, WorkingPoint::TIGHT);
+		}
+		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDVETO)
+		{
+			validElectron = validElectron && IsCutBasedSummer16(&(*electron), event, WorkingPoint::VETO);
+		}
 		else if (electronIDType != ElectronIDType::NONE)
 			LOG(FATAL) << "Electron ID type of type " << Utility::ToUnderlyingValue(electronIDType) << " not yet implemented!";
 	}
@@ -296,6 +312,11 @@ bool HttValidElectronsProducer::IsCutBasedSpring15(KElectron* electron, event_ty
 	return electron->getId(ChooseCutBasedId(event.m_electronMetadata, wp), event.m_electronMetadata);
 }
 
+bool HttValidElectronsProducer::IsCutBasedSummer16(KElectron* electron, event_type const& event, WorkingPoint wp) const
+{
+	return electron->getId(ChooseCutBasedId(event.m_electronMetadata, wp), event.m_electronMetadata);
+}
+
 bool HttValidElectronsProducer::IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const
 {
 	bool validElectron = true;
@@ -320,6 +341,7 @@ bool HttValidElectronsProducer::IsMVANonTrigSpring15(KElectron* electron, event_
 
 	// https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Non_triggering_electron_MVA_AN1
 	// pT always greater than 10 GeV
+	// TODO: cut-values should be made configurable via json file
 	validElectron = validElectron &&
 		( 
 			(std::abs(electron->superclusterPosition.Eta()) < 0.8 && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID ? 0.967083 : 0.913286))
@@ -345,6 +367,8 @@ std::string HttValidElectronsProducer::ChooseCutBasedId(const KElectronMetadata 
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose";
 		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose")))
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose";
+		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose")))
+			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose";
 		else
 			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the loose WP" << std::endl;
 	}
@@ -358,6 +382,8 @@ std::string HttValidElectronsProducer::ChooseCutBasedId(const KElectronMetadata 
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium";
 		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium")))
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium";
+		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium")))
+			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium";
 		else
 			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the medium WP" << std::endl;
 	}
@@ -371,6 +397,8 @@ std::string HttValidElectronsProducer::ChooseCutBasedId(const KElectronMetadata 
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight";
 		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight")))
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight";
+		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight")))
+			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight";
 		else
 			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the tight WP" << std::endl;
 	}
@@ -384,6 +412,8 @@ std::string HttValidElectronsProducer::ChooseCutBasedId(const KElectronMetadata 
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto";
 		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto")))
 			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto";
+		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto")))
+			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto";
 		else
 			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the veto WP" << std::endl;
 	}

--- a/src/Producers/HttValidElectronsProducer.cc
+++ b/src/Producers/HttValidElectronsProducer.cc
@@ -161,51 +161,11 @@ bool HttValidElectronsProducer::AdditionalCriteria(KElectron* electron,
 		{
 			validElectron = validElectron && IsMVANonTrigPhys14(&(*electron), event, true);
 		}
-		else if (electronIDType == ElectronIDType::SPRING15CUTBASEDLOOSE)
+		else if (electronIDType == ElectronIDType::CUTBASED2015ANDLATER)
 		{
 			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
 		}
-		else if (electronIDType == ElectronIDType::SPRING15CUTBASEDMEDIUM)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SPRING15CUTBASEDTIGHT)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SPRING15CUTBASEDVETO)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::MVANONTRIGSPRING15LOOSE)
-		{
-			validElectron = validElectron && IsMVABased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::MVANONTRIGSPRING15TIGHT)
-		{
-			validElectron = validElectron && IsMVABased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDLOOSE)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDMEDIUM)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDTIGHT)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::SUMMER16CUTBASEDVETO)
-		{
-			validElectron = validElectron && IsCutBased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::MVAGENERALPURPOSESPRING16LOOSE)
-		{
-			validElectron = validElectron && IsMVABased(&(*electron), event, settings);
-		}
-		else if (electronIDType == ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT)
+		else if (electronIDType == ElectronIDType::MVABASED2015ANDLATER)
 		{
 			validElectron = validElectron && IsMVABased(&(*electron), event, settings);
 		}

--- a/src/Producers/HttValidElectronsProducer.cc
+++ b/src/Producers/HttValidElectronsProducer.cc
@@ -190,6 +190,14 @@ bool HttValidElectronsProducer::AdditionalCriteria(KElectron* electron,
 		{
 			validElectron = validElectron && IsCutBasedSummer16(&(*electron), event, WorkingPoint::VETO);
 		}
+		else if (electronIDType == ElectronIDType::MVAGENERALPURPOSESPRING16LOOSE)
+		{
+			validElectron = validElectron && IsMVAGeneralPurposeSpring16(&(*electron), event, false);
+		}
+		else if (electronIDType == ElectronIDType::MVAGENERALPURPOSESPRING16TIGHT)
+		{
+			validElectron = validElectron && IsMVAGeneralPurposeSpring16(&(*electron), event, true);
+		}
 		else if (electronIDType != ElectronIDType::NONE)
 			LOG(FATAL) << "Electron ID type of type " << Utility::ToUnderlyingValue(electronIDType) << " not yet implemented!";
 	}
@@ -349,6 +357,25 @@ bool HttValidElectronsProducer::IsMVANonTrigSpring15(KElectron* electron, event_
 			(std::abs(electron->superclusterPosition.Eta()) > 0.8 && std::abs(electron->superclusterPosition.Eta()) < DefaultValues::EtaBorderEB && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID? 0.929117 : 0.805013))
 			||
 			(std::abs(electron->superclusterPosition.Eta()) > DefaultValues::EtaBorderEB && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID ? 0.726311 : 0.358969))
+		);
+
+	return validElectron;
+}
+
+bool HttValidElectronsProducer::IsMVAGeneralPurposeSpring16(KElectron* electron, event_type const& event, bool tightID) const
+{
+	bool validElectron = true;
+
+	// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#General_Purpose_MVA_training_det
+	// pT always greater than 10 GeV
+	// TODO: cut-values should be made configurable via json file
+	validElectron = validElectron &&
+		(
+			(std::abs(electron->superclusterPosition.Eta()) < 0.8 && electron->getId("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values", event.m_electronMetadata) > (tightID ? 0.941 : 0.837))
+			||
+			(std::abs(electron->superclusterPosition.Eta()) > 0.8 && std::abs(electron->superclusterPosition.Eta()) < DefaultValues::EtaBorderEB && electron->getId("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values", event.m_electronMetadata) > (tightID ? 0.899 : 0.715))
+			||
+			(std::abs(electron->superclusterPosition.Eta()) > DefaultValues::EtaBorderEB && electron->getId("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values", event.m_electronMetadata) > (tightID ? 0.758 : 0.357))
 		);
 
 	return validElectron;

--- a/src/Producers/HttValidElectronsProducer.cc
+++ b/src/Producers/HttValidElectronsProducer.cc
@@ -146,30 +146,6 @@ bool HttValidElectronsProducer::AdditionalCriteria(KElectron* electron,
 		{
 			validElectron = validElectron && IsMVATrigElectronTTHSummer2013(&(*electron), event, true);
 		}
-		else if (electronIDType == ElectronIDType::PHYS14CUTBASEDLOOSE)
-		{
-			validElectron = validElectron && IsCutBasedPhys14(&(*electron), event, WorkingPoint::LOOSE);
-		}
-		else if (electronIDType == ElectronIDType::PHYS14CUTBASEDMEDIUM)
-		{
-			validElectron = validElectron && IsCutBasedPhys14(&(*electron), event, WorkingPoint::MEDIUM);
-		}
-		else if (electronIDType == ElectronIDType::PHYS14CUTBASEDTIGHT)
-		{
-			validElectron = validElectron && IsCutBasedPhys14(&(*electron), event, WorkingPoint::TIGHT);
-		}
-		else if (electronIDType == ElectronIDType::PHYS14CUTBASEDVETO)
-		{
-			validElectron = validElectron && IsCutBasedPhys14(&(*electron), event, WorkingPoint::VETO);
-		}
-		else if (electronIDType == ElectronIDType::MVANONTRIGPHYS14LOOSE)
-		{
-			validElectron = validElectron && IsMVANonTrigPhys14(&(*electron), event, false);
-		}
-		else if (electronIDType == ElectronIDType::MVANONTRIGPHYS14TIGHT)
-		{
-			validElectron = validElectron && IsMVANonTrigPhys14(&(*electron), event, true);
-		}
 		else if (electronIDType == ElectronIDType::CUTBASED2015ANDLATER)
 		{
 			assert(CheckElectronMetadata(event.m_electronMetadata, electronIDName, electronIDInMetadata));
@@ -294,35 +270,12 @@ bool HttValidElectronsProducer::IsMVANonTrigElectronHttSummer2013(KElectron* ele
 	return validElectron;
 }
 
-bool HttValidElectronsProducer::IsCutBasedPhys14(KElectron* electron, event_type const& event, WorkingPoint wp) const
-{
-	return electron->getId(ChooseCutBasedId(event.m_electronMetadata, wp), event.m_electronMetadata);
-}
-
 bool HttValidElectronsProducer::IsCutBased(KElectron* electron, event_type const& event, const std::string &idName) const
 {
 	bool validElectron = true;
 
 	validElectron = validElectron
 			&& electron->getId(idName, event.m_electronMetadata);
-
-	return validElectron;
-}
-
-bool HttValidElectronsProducer::IsMVANonTrigPhys14(KElectron* electron, event_type const& event, bool tightID) const
-{
-	bool validElectron = true;
-
-	// https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#Non_triggering_electron_MVA
-	// pT always greater than 10 GeV
-	validElectron = validElectron &&
-		( 
-			(std::abs(electron->superclusterPosition.Eta()) < 0.8 && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID ? 0.965 : 0.933))
-			||
-			(std::abs(electron->superclusterPosition.Eta()) > 0.8 && std::abs(electron->superclusterPosition.Eta()) < DefaultValues::EtaBorderEB && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID? 0.917 : 0.825))
-			||
-			(std::abs(electron->superclusterPosition.Eta()) > DefaultValues::EtaBorderEB && electron->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) > (tightID ? 0.683 : 0.337))
-		);
 
 	return validElectron;
 }
@@ -369,93 +322,6 @@ bool HttValidElectronsProducer::CheckElectronMetadata(const KElectronMetadata *m
 	checkedAlready = true;
 
 	return checkedAlready;
-}
-
-std::string HttValidElectronsProducer::ChooseCutBasedId(const KElectronMetadata *meta, WorkingPoint wp) const
-{
-	std::string stringID;
-
-	if (wp == WorkingPoint::LOOSE) {
-		if (Utility::Contains(meta->idNames, std::string("cutBasedEleIdPHYS14Loose")))
-			stringID = "cutBasedEleIdPHYS14Loose";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-loose")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-loose";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-loose";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose";
-		else
-			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the loose WP" << std::endl;
-	}
-
-	if (wp == WorkingPoint::MEDIUM) {
-		if (Utility::Contains(meta->idNames, std::string("cutBasedEleIdPHYS14Medium")))
-			stringID = "cutBasedEleIdPHYS14Medium";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-medium")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-medium";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium";
-		else
-			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the medium WP" << std::endl;
-	}
-
-	if (wp == WorkingPoint::TIGHT) {
-		if (Utility::Contains(meta->idNames, std::string("cutBasedEleIdPHYS14Tight")))
-			stringID = "cutBasedEleIdPHYS14Tight";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-tight")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-tight";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-tight";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight";
-		else
-			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the tight WP" << std::endl;
-	}
-
-	if (wp == WorkingPoint::VETO) {
-		if (Utility::Contains(meta->idNames, std::string("cutBasedEleIdPHYS14Veto")))
-			stringID = "cutBasedEleIdPHYS14Veto";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-veto")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-veto";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-veto";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto";
-		else if (Utility::Contains(meta->idNames, std::string("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto")))
-			stringID = "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto";
-		else
-			LOG(FATAL) << "HttValidElectronsProducer::ChooseCutBasedId: could not find any Id for the veto WP" << std::endl;
-	}
-
-	return stringID;
-}
-
-std::string HttValidElectronsProducer::ChooseMvaNonTrigId(const KElectronMetadata *meta) const
-{
-	std::string stringID;
-
-	if (Utility::Contains(meta->idNames, std::string("mvaNonTrigV025nsPHYS14")))
-		stringID = "mvaNonTrigV025nsPHYS14";
-	else if (Utility::Contains(meta->idNames, std::string("mvaNonTrig25nsPHYS14")))
-		stringID = "mvaNonTrig25nsPHYS14";
-	else if (Utility::Contains(meta->idNames, std::string("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Phys14NonTrigValues")))
-		stringID = "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Phys14NonTrigValues";
-	else if (Utility::Contains(meta->idNames, std::string("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")))
-		stringID = "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values";
-	else if (Utility::Contains(meta->idNames, std::string("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values")))
-		stringID = "electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values";
-	else
-		LOG(FATAL) << "HttValidElectronsProducer::ChooseMvaNotTrigId: could not find any Id" << std::endl;
-
-	return stringID;
 }
 
 HttValidLooseElectronsProducer::HttValidLooseElectronsProducer(

--- a/src/Producers/HttValidElectronsProducer.cc
+++ b/src/Producers/HttValidElectronsProducer.cc
@@ -80,6 +80,7 @@ void HttValidElectronsProducer::Init(setting_type const& settings)
 	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("leadingEleIsoOverPt", [this](event_type const& event, product_type const& product) {
 		return product.m_validElectrons.size() >= 1 ? SafeMap::GetWithDefault(product.m_electronIsolationOverPt, product.m_validElectrons[0], DefaultValues::UndefinedDouble) : DefaultValues::UndefinedDouble;
 	});
+	// TODO: the lines below still need to be refactored properly to avoid too many string comparisons
 	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("id_e_mva_nt_loose_1", [this](event_type const& event, product_type const& product)
 	{
 		return (product.m_validElectrons.size() >= 1 && electronIDType != ElectronIDType::NONE) ? product.m_validElectrons[0]->getId(ChooseMvaNonTrigId(event.m_electronMetadata), event.m_electronMetadata) : DefaultValues::UndefinedFloat;


### PR DESCRIPTION
Dear all,

during the implementation of the 2016 electron id I noticed some problems with the way the producer was implemented:

1.) the producer can only handle kappa tuples that contain no more than one set of electron ids (e.g. Spring15 or Summer16 but NOT both). If there are more, it will always choose the first one implemented as you can see for example [here](https://github.com/cms-analysis/HiggsAnalysis-KITHiggsToTauTau/blob/master/src/Producers/HttValidElectronsProducer.cc#L340-L349).
2.) The electron id string is compared to the ids saved in the metadata object for every electron in the event which is not really necessary and can lead to a decrease in performance (this was actually noticed by Thomas).

Both issues should be fixed now(*) and I restructured the class a bit and made the ids configurable via json configs for more flexibility. I testet everything with ~22000 DY events and the output is identical to what the current master branch yields. I also updated all setting files for electron ids that use 2015 or 2016 data/MC. If I missed any, please let me know.

Please have a look at the changes (specifically in the cpp files) and contact me if you see any issues. Otherwise I will merge it tomorrow afternoon.

Cheers,
Alex

(*) for 2015 and 2016 that is! Phys14 is still a problem but if no one objects to the changes proposed in issue #43, this code will be removed shortly anyhow.